### PR TITLE
Demo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ interface ReadiumSpeechVoice {
 
   // Core identification (required)
   label: string;          // Human-friendly label for the voice
-  name: string;           // System/technical name (matches Web Speech API voiceURI)
+  name: string;           // JSON Name (or Web Speech API name if not found)
+  originalName: string;   // Original name of the voice
   voiceURI?: string;      // For Web Speech API compatibility
   
   // Localization

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,9 +39,9 @@
     <div class="form-group">
       <details class="voice-details">
       <summary>Voice Details</summary>
-        <div id="voice-properties" class="voice-properties">
-          <p>Select a voice to see its properties</p>
-        </div>
+      <div id="voice-properties" class="voice-properties">
+        <p>Select a voice to see its properties</p>
+      </div>
       </details>
     </div>
 
@@ -96,12 +96,14 @@
     </div>
   </div>
 
-  <details class="dev-tools">
-    <summary>Developer Tools</summary>
-    <div class="form-group">
-      <button id="download-voices-btn" class="download-btn">Download All Browser Voices as JSON</button>
-    </div>
-  </details>
+  <div class="form-group">
+    <details class="dev-tools">
+      <summary>Developer Tools</summary>
+      <div class="dev-tools-items">
+        <button id="download-voices-btn" class="download-btn">Download All Browser Voices as JSON</button>
+      </div>
+    </details>
+  </div>
 
   <script type="module" src="./script.js"></script>
 </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -96,6 +96,13 @@
     </div>
   </div>
 
+  <details class="dev-tools">
+    <summary>Developer Tools</summary>
+    <div class="form-group">
+      <button id="download-voices-btn" class="download-btn">Download All Browser Voices as JSON</button>
+    </div>
+  </details>
+
   <script type="module" src="./script.js"></script>
 </body>
 </html>

--- a/demo/script.js
+++ b/demo/script.js
@@ -22,6 +22,7 @@ const jumpToBtn = document.getElementById("jump-to-btn");
 const utteranceIndexInput = document.getElementById("utterance-index");
 const totalUtterancesSpan = document.getElementById("total-utterances");
 const sampleTextDisplay = document.getElementById("sample-text");
+const downloadVoicesBtn = document.getElementById("download-voices-btn");
 
 // Track if user has manually changed the jump input
 let jumpInputUserChanged = false;
@@ -628,6 +629,9 @@ function displayVoiceProperties(voice) {
       updateTestUtterance(currentVoice, languageSelect.value);
     }
   });
+
+  // Download voices button
+  downloadVoicesBtn.addEventListener("click", downloadVoicesAsJson);
 }
 
 // Play test utterance - independent of the navigator
@@ -893,6 +897,51 @@ function updateUI() {
     }
   } catch (error) {
     console.error("Error updating UI:", error);
+  }
+}
+
+// Simple function to get current date for filenames
+function getCurrentDate() {
+  return new Date().toISOString().split("T")[0];
+}
+
+// Function to download voices as JSON
+function downloadVoicesAsJson() {
+  try {
+    const voices = window.speechSynthesis.getVoices();
+    
+    const metadata = {
+      timestamp: new Date().toISOString(),
+      voicesCount: voices.length
+    };
+    
+    const voicesData = voices.map(voice => ({
+      ...voice,
+      // Known properties
+      voiceURI: voice.voiceURI,
+      name: voice.name,
+      lang: voice.lang,
+      localService: voice.localService,
+      default: voice.default
+    }));
+    
+    const exportData = {
+      metadata,
+      voices: voicesData
+    };
+    
+    const dataStr = JSON.stringify(exportData, null, 2);
+    const dataUri = "data:application/json;charset=utf-8," + encodeURIComponent(dataStr);
+    
+    const exportFileDefaultName = `speech-voices-${getCurrentDate()}.json`.replace(/[^a-z0-9.-]+/gi, "-").toLowerCase();
+    
+    const linkElement = document.createElement("a");
+    linkElement.setAttribute("href", dataUri);
+    linkElement.setAttribute("download", exportFileDefaultName);
+    linkElement.click();
+  } catch (error) {
+    console.error("Error downloading voices data:", error);
+    alert("Error downloading voices data. Please check console for details.");
   }
 }
 

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -489,8 +489,10 @@ form > div {
   }
 }
 
-/* Voice Details Section */
-.voice-details {
+/* Expandable Details */
+
+.voice-details,
+.dev-tools {
   background: #f9f9f9;
   border: 1px solid #e0e0e0;
   border-radius: 8px;
@@ -498,7 +500,8 @@ form > div {
   overflow: hidden;
 }
 
-.voice-details summary {
+.voice-details summary,
+.dev-tools summary {
   padding: 12px 16px;
   background: #f0f0f0;
   cursor: pointer;
@@ -509,15 +512,18 @@ form > div {
   transition: background-color 0.2s ease;
 }
 
-.voice-details summary:hover {
+.voice-details summary:hover,
+.dev-tools summary:hover {
   background: #e8e8e8;
 }
 
-.voice-details[open] summary {
+.voice-details[open] summary,
+.dev-tools summary:hover {
   background: #e0e0e0;
 }
 
-.voice-properties {
+.voice-properties,
+.dev-tools-items {
   padding: 16px;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   font-size: 14px;
@@ -525,6 +531,8 @@ form > div {
   color: #333;
   background: white;
 }
+
+/* Voice Details Section */
 
 .voice-property {
   display: flex;
@@ -566,7 +574,8 @@ form > div {
   font-style: italic;
 }
 
-/* Download button (blue) */
+/* Dev tools items */
+
 .download-btn {
   background-color: #2196F3; /* Blue to match navigation buttons */
   color: white;

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -565,3 +565,22 @@ form > div {
   color: #9e9e9e;
   font-style: italic;
 }
+
+/* Download button (blue) */
+.download-btn {
+  background-color: #2196F3; /* Blue to match navigation buttons */
+  color: white;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+  display: inline-block;
+  margin-top: 10px;
+}
+
+.download-btn:hover:not(:disabled) {
+  background-color: #1976D2; /* Slightly darker blue on hover */
+  opacity: 1;
+}

--- a/src/WebSpeech/WebSpeechVoiceManager.ts
+++ b/src/WebSpeech/WebSpeechVoiceManager.ts
@@ -1,4 +1,4 @@
-import { JSONVoice, ReadiumSpeechVoice, TGender, TQuality, TSource } from "../voices/types";
+import { ReadiumSpeechJSONVoice, ReadiumSpeechVoice, TGender, TQuality, TSource } from "../voices/types";
 import { getTestUtterance, getVoices } from "../voices/languages";
 import { 
   isNoveltyVoice, 
@@ -183,7 +183,7 @@ export class WebSpeechVoiceManager {
    */
   private inferVoiceQuality(
     voice: SpeechSynthesisVoice,
-    jsonVoice: JSONVoice | undefined,
+    jsonVoice: ReadiumSpeechJSONVoice | undefined,
     duplicatesCount: number
   ): TQuality {
     // 1. Try package name
@@ -217,7 +217,7 @@ export class WebSpeechVoiceManager {
    * Find matching JSON voice by name or alternative names
    * @private
    */
-  private findMatchingJsonVoice(langVoices: any[], normalizedName: string) {
+  private findMatchingJsonVoice(langVoices: any[], normalizedName: string): ReadiumSpeechJSONVoice | undefined {
     return langVoices.find(v => 
       this.normalizeVoiceName(v.name) === normalizedName || 
       v.altNames?.some((alt: string) => this.normalizeVoiceName(alt) === normalizedName)
@@ -500,7 +500,7 @@ export class WebSpeechVoiceManager {
           return {
             ...jsonVoice,
             source: "json",
-            name: voice.name,
+            originalName: voice.name,
             language: voice.lang,
             voiceURI: voice.voiceURI,
             quality,
@@ -516,6 +516,7 @@ export class WebSpeechVoiceManager {
           source: "browser",
           label: this.normalizeVoiceName(voice.name),
           name: voice.name,
+          originalName: voice.name,
           language: formattedLang,
           voiceURI: voice.voiceURI,
           quality,
@@ -538,7 +539,8 @@ export class WebSpeechVoiceManager {
     
     return this.browserVoices.find(v => 
       v.voiceURI === voice.voiceURI || 
-      v.name === voice.name
+      v.name === voice.originalName ||
+      this.normalizeVoiceName(v.name) === this.normalizeVoiceName(voice.name)
     );
   }
 

--- a/src/WebSpeech/WebSpeechVoiceManager.ts
+++ b/src/WebSpeech/WebSpeechVoiceManager.ts
@@ -500,9 +500,10 @@ export class WebSpeechVoiceManager {
           return {
             ...jsonVoice,
             source: "json",
-            quality,
-            voiceURI: voice.voiceURI,
+            name: voice.name,
             language: voice.lang,
+            voiceURI: voice.voiceURI,
+            quality,
             isDefault: voice.default || false,
             offlineAvailability: voice.localService || false,
             isNovelty: isNoveltyVoice(voice.name, voice.voiceURI),
@@ -513,11 +514,11 @@ export class WebSpeechVoiceManager {
         // No match found in JSON, create basic voice object
         return {
           source: "browser",
-          label: voice.name,
+          label: this.normalizeVoiceName(voice.name),
           name: voice.name,
           language: formattedLang,
-          quality,
           voiceURI: voice.voiceURI,
+          quality,
           isDefault: voice.default || false,
           offlineAvailability: voice.localService || false,
           isNovelty: isNoveltyVoice(voice.name, voice.voiceURI),
@@ -535,10 +536,9 @@ export class WebSpeechVoiceManager {
   convertToSpeechSynthesisVoice(voice: ReadiumSpeechVoice): SpeechSynthesisVoice | undefined {
     if (!voice) return undefined;
     
-    const normalizedVoiceName = this.normalizeVoiceName(voice.name);
     return this.browserVoices.find(v => 
       v.voiceURI === voice.voiceURI || 
-      this.normalizeVoiceName(v.name) === normalizedVoiceName
+      v.name === voice.name
     );
   }
 

--- a/src/WebSpeech/WebSpeechVoiceManager.ts
+++ b/src/WebSpeech/WebSpeechVoiceManager.ts
@@ -481,8 +481,13 @@ export class WebSpeechVoiceManager {
         const voiceKey = `${voice.lang.toLowerCase()}_${normalizedName}`;
         const duplicatesCount = duplicateCounts.get(voiceKey) || 1;
         
-        // Get voices for the specific language
-        const langVoices = getVoices(baseLang);
+        // First try with the full language code to handle variants like zh-HK
+        let langVoices = getVoices(formattedLang);
+        
+        // If no voices found, try with the base language code
+        if (!langVoices || langVoices.length === 0) {
+          langVoices = getVoices(baseLang);
+        }
         
         // Find matching JSON voice
         const jsonVoice = this.findMatchingJsonVoice(langVoices, normalizedName);
@@ -497,6 +502,7 @@ export class WebSpeechVoiceManager {
             source: "json",
             quality,
             voiceURI: voice.voiceURI,
+            language: voice.lang,
             isDefault: voice.default || false,
             offlineAvailability: voice.localService || false,
             isNovelty: isNoveltyVoice(voice.name, voice.voiceURI),

--- a/src/WebSpeech/webSpeechEngine.ts
+++ b/src/WebSpeech/webSpeechEngine.ts
@@ -254,11 +254,6 @@ export class WebSpeechEngine implements ReadiumSpeechPlaybackEngine {
 
     const utterance = this.createUtterance(text);
 
-    // Configure utterance
-    if (content.language) {
-      utterance.lang = content.language;
-    }
-
     // Enhanced voice selection with MSNatural detection
     const selectedVoice = this.getCurrentVoiceForUtterance(this.currentVoice);
 
@@ -268,7 +263,12 @@ export class WebSpeechEngine implements ReadiumSpeechPlaybackEngine {
       
       if (nativeVoice) {
         utterance.voice = nativeVoice; // Use the real native voice from cache
+        utterance.lang = nativeVoice.lang;
       }
+    }
+
+    if (content.language) {
+      utterance.lang = content.language;
     }
 
     utterance.rate = this.rate;

--- a/src/WebSpeech/webSpeechEngine.ts
+++ b/src/WebSpeech/webSpeechEngine.ts
@@ -87,7 +87,7 @@ export class WebSpeechEngine implements ReadiumSpeechPlaybackEngine {
       this.voices = this.voiceManager.getVoices();
 
       // Find the best matching voice for the user's language using the optimized method
-      this.defaultVoice = this.voiceManager.getDefaultVoice(navigator.language || "en", this.voices);
+      this.defaultVoice = this.voiceManager.getDefaultVoice(navigator.languages[0] || "en", this.voices);
 
       this.initialized = true;
       return true;

--- a/src/WebSpeech/webSpeechEngine.ts
+++ b/src/WebSpeech/webSpeechEngine.ts
@@ -170,6 +170,15 @@ export class WebSpeechEngine implements ReadiumSpeechPlaybackEngine {
         this.currentUtteranceIndex = 0;
       }
     }
+
+    // Update default voice if language changed
+    if (
+      this.voiceManager && 
+      this.defaultVoice && this.currentVoice &&
+      this.currentVoice.language !== this.defaultVoice.language
+    ) {
+      this.defaultVoice = this.voiceManager.getDefaultVoice(this.currentVoice.language, this.voices);
+    }
   }
 
   getAvailableVoices(): Promise<ReadiumSpeechVoice[]> {

--- a/src/voices/packages.ts
+++ b/src/voices/packages.ts
@@ -1,20 +1,38 @@
-export enum PackageQuality {
-  VeryLow = "super-compact",
-  Low = "compact",
-  Normal = "enhanced",
-  High = "premium"
-}
-
 import { TQuality } from "./types";
+
+type PackageQuality = {
+  [key: string]: {
+    values: string[];
+    quality: TQuality;
+  };
+};
+
+const packageQualities: PackageQuality = {
+  low: {
+    values: ["super-compact", "compact"],
+    quality: "low"
+  },
+  normal: {
+    values: ["enhanced"],
+    quality: "normal"
+  },
+  high: {
+    values: ["premium"],
+    quality: "high"
+  }
+};
 
 export const getInferredQualityFromPackageName = (voiceName: string): TQuality | undefined => {
   if (!voiceName) return undefined;
   
   const lowerName = voiceName.toLowerCase();
-  if (lowerName.includes(`.${PackageQuality.VeryLow}.`)) return "veryLow";
-  if (lowerName.includes(`.${PackageQuality.Low}.`)) return "low";
-  if (lowerName.includes(`.${PackageQuality.Normal}.`)) return "normal";
-  if (lowerName.includes(`.${PackageQuality.High}.`)) return "high";
+  
+  // Check each quality level
+  for (const quality of Object.values(packageQualities)) {
+    if (quality.values.some(value => lowerName.includes(`.${value}.`))) {
+      return quality.quality;
+    }
+  }
   
   return undefined;
 }

--- a/src/voices/types.ts
+++ b/src/voices/types.ts
@@ -31,7 +31,7 @@ export type TBrowser = "ChromeDesktop" | "Edge" | "Firefox" | "Safari";
 /**
  * Represents a voice from the JSON data file
  */
-export interface JSONVoice {
+export interface ReadiumSpeechJSONVoice {
   label?: string;
   name: string;
   localizedName?: "android" | "apple";
@@ -66,7 +66,8 @@ export interface ReadiumSpeechVoice {
 
   // Core identification (required)
   label: string;          // Human-friendly label for the voice
-  name: string;           // System/technical name (matches Web Speech API voiceURI)
+  name: string;           // JSON Name (or Web Speech API name if not found)
+  originalName: string;   // Web Speech API name
   voiceURI?: string;      // For Web Speech API compatibility
   
   // Localization

--- a/test/WebSpeechVoiceManager.test.ts
+++ b/test/WebSpeechVoiceManager.test.ts
@@ -231,7 +231,7 @@ testWithContext("deduplication: keeps higher quality voice from voiceURI package
   const [resultVoice] = (manager as any).parseToReadiumSpeechVoices([lowVoice, normalVoice]);
   
   // Verify the result
-  t.is(resultVoice.name, "Samantha", "Should keep the json name of the voice");
+  t.is(resultVoice.name, "Samantha (enhanced)", "Should keep the name of the voice for retrieval");
   t.deepEqual(resultVoice.quality, "normal", "Should keep the voice with normal quality");
 });
 
@@ -267,7 +267,7 @@ testWithContext("deduplication: keeps higher quality voice from voiceURI string"
   const [resultVoice] = (manager as any).parseToReadiumSpeechVoices([basicVoice, enhancedVoice]);
   
   // Verify the result
-  t.is(resultVoice.name, "Samantha", "Should keep the json name of the voice");
+  t.is(resultVoice.name, "Samantha (Premium)", "Should keep the name of the voice for retrieval");
   t.deepEqual(resultVoice.quality, "high", "Should keep the voice with high quality");
 });
 
@@ -296,7 +296,7 @@ testWithContext("deduplication: keeps higher quality voice from json quality arr
   
   // Verify only the higher quality voice remains with its original name
   t.is(deduped.length, 1, "Should only keep one voice after deduplication");
-  t.is(deduped[0].name, "Samantha", "Should keep the json name of the voice");
+  t.is(deduped[0].name, "Samantha (Superior)", "Should keep the name of the voice for retrieval");
   t.is(deduped[0].voiceURI, "Samantha superior", "Should keep the voice with superior quality");
   t.deepEqual(deduped[0].quality, "normal", "Should find the voice with normal quality from the array");
 });

--- a/test/WebSpeechVoiceManager.test.ts
+++ b/test/WebSpeechVoiceManager.test.ts
@@ -203,14 +203,6 @@ testWithContext("deduplication: keeps higher quality voice from voiceURI package
   const manager = t.context.manager;
   
   // Define test voices once
-  const veryLowVoice = {
-    voiceURI: "com.apple.speech.synthesis.voice.super-compact.samantha",
-    name: "Samantha (very low)",
-    lang: "en-US",
-    localService: true,
-    default: false
-  };
-
   const lowVoice = {
     voiceURI: "com.apple.speech.synthesis.voice.compact.samantha",
     name: "Samantha",
@@ -219,20 +211,28 @@ testWithContext("deduplication: keeps higher quality voice from voiceURI package
     default: false
   };
 
+  const normalVoice = {
+    voiceURI: "com.apple.speech.synthesis.voice.enhanced.samantha",
+    name: "Samantha (enhanced)",
+    lang: "en-US",
+    localService: true,
+    default: false
+  };
+
   // 1. First parse separately to verify individual qualities
-  const veryLowQualityVoice = (manager as any).parseToReadiumSpeechVoices([veryLowVoice])[0];
   const lowQualityVoice = (manager as any).parseToReadiumSpeechVoices([lowVoice])[0];
+  const normalQualityVoice = (manager as any).parseToReadiumSpeechVoices([normalVoice])[0];
 
   // Verify individual qualities
-  t.is(veryLowQualityVoice.quality, "veryLow", "Very low quality voice should have very low quality");
   t.is(lowQualityVoice.quality, "low", "Low quality voice should have low quality");
+  t.is(normalQualityVoice.quality, "normal", "Normal quality voice should have normal quality");
 
   // 2. Now parse both together to test deduplication
-  const [resultVoice] = (manager as any).parseToReadiumSpeechVoices([veryLowVoice, lowVoice]);
+  const [resultVoice] = (manager as any).parseToReadiumSpeechVoices([lowVoice, normalVoice]);
   
   // Verify the result
   t.is(resultVoice.name, "Samantha", "Should keep the json name of the voice");
-  t.deepEqual(resultVoice.quality, "low", "Should keep the voice with low quality");
+  t.deepEqual(resultVoice.quality, "normal", "Should keep the voice with normal quality");
 });
 
 testWithContext("deduplication: keeps higher quality voice from voiceURI string", (t) => {


### PR DESCRIPTION
Following the previous merge, several issues have been spotted. In particular:

- [x] incorrect (default) voice is used when speaking utterances from the sample text in another language, but not test utterances
- [x] `zh-HK` is not retrieved correctly in JSON data
- [x] Package name quality inference is too aggressive, `super-compact` filters way too many voices in Safari across platforms

Handling of languages will be addressed in a subsequent PR. Specifically: 

- handling of `preferredLanguages` is not smart enough when sorting
- `defaultRegion` is not being used as a fallback when sorting `language`