### PR TITLE
New voices for iOS/iPadOS/macOS 26

### DIFF
--- a/docs/VoicesAndFiltering.md
+++ b/docs/VoicesAndFiltering.md
@@ -46,6 +46,7 @@ In its current state, it covers 43 languages:
 * [Italian](../json/it.json)
 * [Japanese](../json/ja.json)
 * [Kannada](../json/kn.json)
+* [Kazakh](../json/kk.json)
 * [Korean](../json/ko.json)
 * [Malay](../json/ms.json)
 * [Marathi](../json/mr.json)

--- a/json/de.json
+++ b/json/de.json
@@ -156,8 +156,8 @@
       "preloaded": true
     },
     {
-      "label": "Google Deutsch",
-      "name": "Weibliche Google-Stimme (Deutschland)",
+      "label": "Weibliche Google-Stimme",
+      "name": "Google Deutsch",
       "language": "de-DE",
       "gender": "female",
       "quality": [

--- a/json/en.json
+++ b/json/en.json
@@ -1185,6 +1185,46 @@
       "preloaded": true
     },
     {
+      "label": "Aman",
+      "name": "Aman",
+      "nativeID": [
+        "com.apple.voice.Aman"
+      ],
+      "localizedName": "apple",
+      "language": "en-IN",
+      "gender": "male",
+      "quality": [
+        "high"
+      ],
+      "rate": 1,
+      "pitch": 1,
+      "os": [
+        "macOS",
+        "iOS",
+        "iPadOS"
+      ]
+    },
+    {
+      "label": "Tara",
+      "name": "Tara",
+      "nativeID": [
+        "com.apple.voice.Tara"
+      ],
+      "localizedName": "apple",
+      "language": "en-IN",
+      "gender": "female",
+      "quality": [
+        "high"
+      ],
+      "rate": 1,
+      "pitch": 1,
+      "os": [
+        "macOS",
+        "iOS",
+        "iPadOS"
+      ]
+    },
+    {
       "label": "Isha",
       "name": "Isha",
       "localizedName": "apple",

--- a/json/es.json
+++ b/json/es.json
@@ -863,8 +863,11 @@
       ]
     },
     {
-      "label": "Francisca",
-      "name": "Francisca",
+      "label": "Francesca",
+      "name": "Francesca",
+      "nativeID": [
+        "com.apple.voice.enhanced.es-CL.Francisca"
+      ],
       "localizedName": "apple",
       "language": "es-CL",
       "gender": "female",

--- a/json/ja.json
+++ b/json/ja.json
@@ -43,7 +43,7 @@
       "language": "ja-JP",
       "gender": "male",
       "quality": [
-        "veryHigh"
+        "high"
       ],
       "rate": 1,
       "pitch": 1,

--- a/json/ja.json
+++ b/json/ja.json
@@ -126,26 +126,6 @@
       ]
     },
     {
-      "label": "Hattori",
-      "name": "Hattori",
-      "nativeID": [
-        "com.apple.ttsbundle.siri_Hattori_ja-JP_premium"
-      ],
-      "localizedName": "apple",
-      "language": "ja-JP",
-      "gender": "male",
-      "quality": [
-        "veryHigh"
-      ],
-      "rate": 1,
-      "pitch": 1,
-      "os": [
-        "macOS",
-        "iOS",
-        "iPadOS"
-      ]
-    },
-    {
       "label": "Ayumi",
       "name": "Microsoft Ayumi - Japanese (Japan)",
       "language": "ja-JP",

--- a/json/ja.json
+++ b/json/ja.json
@@ -34,6 +34,26 @@
       "preloaded": true
     },
     {
+      "label": "Hattori",
+      "name": "Hattori",
+      "nativeID": [
+        "com.apple.ttsbundle.siri_Hattori_ja-JP_premium"
+      ],
+      "localizedName": "apple",
+      "language": "ja-JP",
+      "gender": "male",
+      "quality": [
+        "veryHigh"
+      ],
+      "rate": 1,
+      "pitch": 1,
+      "os": [
+        "macOS",
+        "iOS",
+        "iPadOS"
+      ]
+    },
+    {
       "label": "Google の女性の声",
       "name": "Google 日本語",
       "note": "This voice is pre-loaded in Chrome on desktop. Utterances that are longer than 14 seconds long can trigger a bug with this voice, check the notes in the project's README for more information.",
@@ -108,12 +128,14 @@
     {
       "label": "Hattori",
       "name": "Hattori",
+      "nativeID": [
+        "com.apple.ttsbundle.siri_Hattori_ja-JP_premium"
+      ],
       "localizedName": "apple",
       "language": "ja-JP",
       "gender": "male",
       "quality": [
-        "low",
-        "normal"
+        "veryHigh"
       ],
       "rate": 1,
       "pitch": 1,

--- a/json/kk.json
+++ b/json/kk.json
@@ -1,0 +1,27 @@
+{
+  "language": "kk",
+  "defaultRegion": "kk-KZ",
+  "testUtterance": "Sälemetsiz be, meniñ atım {name} jäne men qazaq dawısımın.",
+  "voices": [
+    {
+      "label": "Aru",
+      "name": "Aru",
+      "nativeID": [
+        "com.apple.voice.Aru"
+      ],
+      "localizedName": "apple",
+      "language": "kk-KZ",
+      "gender": "male",
+      "quality": [
+        "high"
+      ],
+      "rate": 1,
+      "pitch": 1,
+      "os": [
+        "macOS",
+        "iOS",
+        "iPadOS"
+      ]
+    }
+  ]
+}

--- a/json/kk.json
+++ b/json/kk.json
@@ -4,6 +4,36 @@
   "testUtterance": "Sälemetsiz be, meniñ atım {name} jäne men qazaq dawısımın.",
   "voices": [
     {
+      "label": "Aigul",
+      "name": "Microsoft Aigul Online (Natural) - Kazakh (Kazakhstan)",
+      "language": "kk-KZ",
+      "gender": "female",
+      "quality": [
+        "veryHigh"
+      ],
+      "rate": 1,
+      "pitchControl": false,
+      "browser": [
+        "Edge"
+      ],
+      "preloaded": true
+    },
+    {
+      "label": "Daulet",
+      "name": "Microsoft Daulet Online (Natural) - Kazakh (Kazakhstan)",
+      "language": "kk-KZ",
+      "gender": "male",
+      "quality": [
+        "veryHigh"
+      ],
+      "rate": 1,
+      "pitchControl": false,
+      "browser": [
+        "Edge"
+      ],
+      "preloaded": true
+    },
+    {
       "label": "Aru",
       "name": "Aru",
       "nativeID": [


### PR DESCRIPTION
While testing on Firefox, I noticed three new voices:

- Aman (Indian English)
- Tara (Indian English)
- Aru (Kazakh)

Upon further investigation, it seems that Aman/Tara are both Pendjabi and English Indian voices, but the Pendjabi ones don't show up (yet?) in any browser.

All three voices were added in iOS/iPadOS/macOS 26.

I've also noticed that Hattori was replaced by a much higher quality version which seems to be designed for Siri. Weirdly enough, it doesn't show any usable name at all (just "- (premium)"), but I've updated Hattori anyway and added the package name.

Unlike Aman/Tara/Aru, Hattori also shows up in Chrome. As usual, Safari is lagging behind and doesn't show any of them.

Since this PR adds support for Kazakh, I also documented the Microsoft Edge voices available for this language.