### PR TITLE
Languages handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ async function setupVoices() {
     
     // Get voices with filters
     const filteredVoices = voiceManager.getVoices({
-      language: ["en", "fr"],
+      languages: ["en", "fr"],
       gender: "female",
       quality: "high",
       offlineOnly: true,
@@ -105,7 +105,7 @@ async function setupVoices() {
     
     // Get voices grouped by language
     const voices = voiceManager.getVoices();
-    const groupedByLanguage = voiceManager.groupVoices(voices, "language");
+    const groupedByLanguage = voiceManager.groupVoices(voices, "languages");
     
     // Get a test utterance for a specific language
     const testText = voiceManager.getTestUtterance("en");

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Fetches all available voices that match the specified filter criteria.
 
 ```typescript
 interface VoiceFilterOptions {
-  language?: string | string[];  // Filter by language code(s) (e.g., "en", "fr")
+  languages?: string | string[];  // Filter by language code(s) (e.g., "en", "fr-FR")
   source?: TSource;  // Filter by voice source ("json" | "browser")
   gender?: TGender;  // "male" | "female" | "other"
   quality?: TQuality | TQuality[];  // "high" | "medium" | "low" | "veryLow"
@@ -175,12 +175,12 @@ Filters voices based on the specified criteria.
 #### Group Voices
 
 ```typescript
-voiceManager.groupVoices(voices: ReadiumSpeechVoice[], groupBy: "language" | "region" | "gender" | "quality" | "provider"): VoiceGroup
+voiceManager.groupVoices(voices: ReadiumSpeechVoice[], groupBy: "languages" | "region" | "gender" | "quality" | "provider"): VoiceGroup
 ```
 
 Organizes voices into groups based on the specified criteria. The available grouping options are:
 
-- `"language"`: Groups voices by their language code
+- `"languages"`: Groups voices by their language code
 - `"region"`: Groups voices by their region
 - `"gender"`: Groups voices by gender
 - `"quality"`: Groups voices by quality level
@@ -196,7 +196,7 @@ Arranges voices according to the specified sorting criteria. The `SortOptions` i
 
 ```typescript
 interface SortOptions {
-  by: "name" | "language" | "gender" | "quality" | "region";
+  by: "name" | "languages" | "gender" | "quality" | "region";
   order?: "asc" | "desc";
 }
 ```

--- a/demo/article/script.js
+++ b/demo/article/script.js
@@ -28,7 +28,7 @@ async function initialize() {
     voiceManager = await WebSpeechVoiceManager.initialize();
     
     // Only get English voices
-    allVoices = voiceManager.getVoices({language: "en"});
+    allVoices = voiceManager.getVoices({languages: "en"});
     
     // Initialize the navigator
     navigator = new WebSpeechReadAloudNavigator();

--- a/demo/script.js
+++ b/demo/script.js
@@ -88,7 +88,7 @@ async function init() {
         name: lang.label
       })),
       { 
-        by: "language",
+        by: "languages",
         order: "asc",
         preferredLanguages: window.navigator.languages
       }
@@ -285,8 +285,8 @@ function filterVoices() {
   
   // Now apply language filter if needed
   if (language) {
-    filterOptions.language = language;
-    filteredVoices = voiceManager.filterVoices(voicesFilteredExceptLanguage, { language });
+    filterOptions.languages = language;
+    filteredVoices = voiceManager.filterVoices(voicesFilteredExceptLanguage, { languages: language });
   } else {
     filteredVoices = voicesFilteredExceptLanguage;
   }
@@ -306,7 +306,7 @@ function filterVoices() {
 }
 
 // Populate the voice dropdown with filtered voices
-function populateVoiceDropdown(language = "") {
+function populateVoiceDropdown() {
   voiceSelect.innerHTML = "<option value='' disabled selected>Select a voice</option>";
   
   try {
@@ -320,7 +320,7 @@ function populateVoiceDropdown(language = "") {
 
     // Sort voices with browser's preferred languages first
     const sortedVoices = voiceManager.sortVoices([...filteredVoices], { 
-      by: "language",
+      by: "region",
       order: "asc",
       preferredLanguages: window.navigator.languages
     });
@@ -582,12 +582,11 @@ function setupEventListeners() {
     
     // Get the default voice for the selected language using pre-filtered voices
     if (baseLanguage) {
-      // Find the first matching language from the user's preferences
-      const preferredLanguage = (window.navigator.languages || [window.navigator.language] || [])
-        .find(lang => lang && lang.startsWith(baseLanguage)) || baseLanguage;
-        
+      // Use the full navigator.languages array for proper language preference handling
+      const preferredLanguages = [...(window.navigator.languages || [window.navigator.language] || [baseLanguage])];
+      
       currentVoice = voiceManager.getDefaultVoice(
-        preferredLanguage, 
+        preferredLanguages, 
         filteredVoices.length ? filteredVoices : undefined
       );
       

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/speech",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.4",
   "description": "Readium Speech is a TypeScript library for implementing a read aloud feature with Web technologies. It follows [best practices](https://github.com/HadrienGardeur/read-aloud-best-practices) gathered through interviews with members of the digital publishing industry.",
   "main": "./build/index.cjs",
   "module": "./build/index.js",

--- a/src/WebSpeech/webSpeechEngine.ts
+++ b/src/WebSpeech/webSpeechEngine.ts
@@ -87,7 +87,7 @@ export class WebSpeechEngine implements ReadiumSpeechPlaybackEngine {
       this.voices = this.voiceManager.getVoices();
 
       // Find the best matching voice for the user's language using the optimized method
-      this.defaultVoice = this.voiceManager.getDefaultVoice(navigator.languages[0] || "en", this.voices);
+      this.defaultVoice = this.voiceManager.getDefaultVoice([...(navigator.languages || ["en"])], this.voices);
 
       this.initialized = true;
       return true;
@@ -177,7 +177,7 @@ export class WebSpeechEngine implements ReadiumSpeechPlaybackEngine {
       this.defaultVoice && this.currentVoice &&
       this.currentVoice.language !== this.defaultVoice.language
     ) {
-      this.defaultVoice = this.voiceManager.getDefaultVoice(this.currentVoice.language, this.voices);
+      this.defaultVoice = this.voiceManager.getDefaultVoice([this.currentVoice.language], this.voices);
     }
   }
 

--- a/test/WebSpeechVoiceManager/filterVoices.test.ts
+++ b/test/WebSpeechVoiceManager/filterVoices.test.ts
@@ -36,11 +36,11 @@ testWithContext("filterVoices: filters by language", (t: ExecutionContext<TestCo
     createTestVoice({ name: "Spanish Voice", language: "es-ES" })
   ];
   
-  const englishVoices = manager.filterVoices(testVoices, { language: "en" });
+  const englishVoices = manager.filterVoices(testVoices, { languages: "en" });
   t.is(englishVoices.length, 2);
   t.true(englishVoices.every(v => v.language.startsWith("en")));
   
-  const multiLangVoices = manager.filterVoices(testVoices, { language: ["en", "fr"] });
+  const multiLangVoices = manager.filterVoices(testVoices, { languages: ["en", "fr"] });
   t.is(multiLangVoices.length, 3);
   t.true(multiLangVoices.every(v => v.language.startsWith("en") || v.language.startsWith("fr")));
 });
@@ -196,7 +196,7 @@ testWithContext("filterVoices: combines multiple filters", (t: ExecutionContext<
   
   // Filter by language and gender
   const englishFemaleVoices = manager.filterVoices(testVoices, { 
-    language: "en", 
+    languages: "en", 
     gender: "female" 
   });
   t.is(englishFemaleVoices.length, 2);
@@ -223,14 +223,14 @@ testWithContext("filterVoices: handles edge cases", (t: ExecutionContext<TestCon
   ];
   
   // Test empty filter arrays
-  const emptyLanguageFilter = manager.filterVoices(testVoices, { language: [] });
+  const emptyLanguageFilter = manager.filterVoices(testVoices, { languages: [] });
   t.is(emptyLanguageFilter.length, 0);
   
   const emptyQualityFilter = manager.filterVoices(testVoices, { quality: undefined });
   t.is(emptyQualityFilter.length, testVoices.length, "Should return all voices when quality is undefined");
   
   // Test case sensitivity for language
-  const caseSensitiveLanguage = manager.filterVoices(testVoices, { language: "EN-us" });
+  const caseSensitiveLanguage = manager.filterVoices(testVoices, { languages: "EN-us" });
   t.is(caseSensitiveLanguage.length, 1); // Should match due to toLowerCase()
   
   // Test invalid quality values - cast to any for testing invalid input
@@ -251,7 +251,7 @@ testWithContext("filterVoices: uses array values for multiple filters", (t: Exec
   
   // Test with array of languages and array of qualities
   const filtered = manager.filterVoices(testVoices, { 
-    language: ["en", "fr"], 
+    languages: ["en", "fr"], 
     quality: ["high", "normal"] 
   });
   t.is(filtered.length, 3);

--- a/test/WebSpeechVoiceManager/getDefaultVoice.test.ts
+++ b/test/WebSpeechVoiceManager/getDefaultVoice.test.ts
@@ -60,14 +60,14 @@ testWithContext("getDefaultVoice: falls back to base language", async (t: Execut
     { 
       voiceURI: "voice1", 
       name: "English Generic", 
-      language: "en",  // Base language
+      language: "en-AU",
       isDefault: false,
       quality: "high" 
     },
     { 
       voiceURI: "voice2", 
       name: "US English", 
-      language: "en-US", 
+      language: "en-US",
       isDefault: false,
       quality: "high" 
     }
@@ -75,10 +75,10 @@ testWithContext("getDefaultVoice: falls back to base language", async (t: Execut
   
   (manager as any).voices = testVoices;
   
-  // Request en-GB which isn't available, should fall back to en
+  // Request en-GB which isn't available, should fall back to alphabetical
   const defaultVoice = await manager.getDefaultVoice("en-GB");
   t.truthy(defaultVoice);
-  t.is(defaultVoice?.language, "en", "Should fall back to base language when exact match not found");
+  t.is(defaultVoice?.language, "en-AU", "Should fall back to first alphabetical region when exact match not found");
 });
 
 testWithContext("getDefaultVoice: respects quality sorting", async (t: ExecutionContext<TestContext>) => {

--- a/test/WebSpeechVoiceManager/getDefaultVoice.test.ts
+++ b/test/WebSpeechVoiceManager/getDefaultVoice.test.ts
@@ -53,6 +53,52 @@ testWithContext("getDefaultVoice: selects highest quality voice regardless of is
   t.is(defaultVoice?.voiceURI, "voice1", "Should select highest quality voice regardless of isDefault flag");
 });
 
+testWithContext("getDefaultVoice: respects preferred languages order", async (t: ExecutionContext<TestContext>) => {
+  const manager = t.context.manager;
+  
+  // Create test voices with different languages
+  const testVoices = [
+    { 
+      voiceURI: "voice1", 
+      name: "French Voice", 
+      language: "fr-FR",
+      isDefault: false,
+      quality: "high" 
+    },
+    { 
+      voiceURI: "voice2", 
+      name: "German Voice", 
+      language: "de-DE",
+      isDefault: false,
+      quality: "high" 
+    },
+    { 
+      voiceURI: "voice3", 
+      name: "Spanish Voice", 
+      language: "es-ES",
+      isDefault: false,
+      quality: "high" 
+    }
+  ];
+  
+  (manager as any).voices = testVoices;
+  
+  // Test with preferred languages in specific order
+  const defaultVoice = await manager.getDefaultVoice(["es-ES", "fr-FR", "de-DE"]);
+  t.truthy(defaultVoice);
+  t.is(defaultVoice?.language, "es-ES", "Should select first preferred language when available");
+  
+  // Test with different order
+  const defaultVoice2 = await manager.getDefaultVoice(["de-DE", "es-ES"]);
+  t.truthy(defaultVoice2);
+  t.is(defaultVoice2?.language, "de-DE", "Should respect the order of preferred languages");
+  
+  // Test with non-existent language first
+  const defaultVoice3 = await manager.getDefaultVoice(["it-IT", "fr-FR", "de-DE"]);
+  t.truthy(defaultVoice3);
+  t.is(defaultVoice3?.language, "fr-FR", "Should skip non-existent languages and use next preferred");
+});
+
 testWithContext("getDefaultVoice: falls back to base language", async (t: ExecutionContext<TestContext>) => {
   const manager = t.context.manager;
   

--- a/test/WebSpeechVoiceManager/getVoices.test.ts
+++ b/test/WebSpeechVoiceManager/getVoices.test.ts
@@ -51,7 +51,7 @@ testWithContext("getVoices: combines all filters", async (t: ExecutionContext<Te
   
   // Test with all filters combined
   const filtered = await manager.getVoices({ 
-    language: ["en", "fr"],
+    languages: ["en", "fr"],
     gender: "male",
     quality: ["high", "normal"],
     provider: "Google",
@@ -155,12 +155,12 @@ testWithContext("getVoices: filters by language", async (t: ExecutionContext<Tes
   const manager = t.context.manager;
   
   // Single language
-  let voices = await manager.getVoices({ language: "en" });
+  let voices = await manager.getVoices({ languages: "en" });
   t.true(voices.length > 0);
   t.true(voices.every((v: ReadiumSpeechVoice) => v.language.startsWith("en")));
   
   // Multiple languages
-  voices = await manager.getVoices({ language: ["en", "fr"] });
+  voices = await manager.getVoices({ languages: ["en", "fr"] });
   t.true(voices.length > 1);
   t.true(voices.some((v: ReadiumSpeechVoice) => v.language.startsWith("en")));
   t.true(voices.some((v: ReadiumSpeechVoice) => v.language.startsWith("fr")));

--- a/test/WebSpeechVoiceManager/groupVoices.test.ts
+++ b/test/WebSpeechVoiceManager/groupVoices.test.ts
@@ -35,7 +35,7 @@ testWithContext("groupVoices: groups by language", (t: ExecutionContext<TestCont
     { voiceURI: "voice3", name: "Voice 3", language: "en-US" }
   ];
   
-  const groups = (manager as any).groupVoices(testVoices, "language");
+  const groups = (manager as any).groupVoices(testVoices, "languages");
   
   // Check that groups were created for each language
   t.truthy(groups["en"]);
@@ -104,7 +104,7 @@ testWithContext("groupVoices: groups by region", (t: ExecutionContext<TestContex
 testWithContext("groupVoices: handles empty voices array", (t: ExecutionContext<TestContext>) => {
   const manager = t.context.manager;
   
-  const groups = manager.groupVoices([], "language");
+  const groups = manager.groupVoices([], "languages");
   t.deepEqual(groups, {});
 });
 
@@ -119,7 +119,7 @@ testWithContext("groupVoices: handles voices with missing properties", (t: Execu
   ];
   
   // Should handle missing properties gracefully
-  const groupsByLanguage = manager.groupVoices(testVoices, "language");
+  const groupsByLanguage = manager.groupVoices(testVoices, "languages");
   t.true(groupsByLanguage.hasOwnProperty("en"));
   t.true(groupsByLanguage.hasOwnProperty("fr"));
   t.true(groupsByLanguage.hasOwnProperty("es"));

--- a/test/WebSpeechVoiceManager/sortVoices.test.ts
+++ b/test/WebSpeechVoiceManager/sortVoices.test.ts
@@ -207,7 +207,21 @@ testWithContext("sortVoices: sorts by preferred languages with region inference"
   t.is(multipleRegionsTest[3].language, getDefaultRegion("es"), "Spanish default region should come first");
   t.is(multipleRegionsTest[4].language, "es-MX", "Other Spanish regions should follow");
 
-  // Test 4: Empty/undefined preferred languages (should sort alphabetically)
+  // Test 4: Keeping prioritization of regions
+  const prioritizedRegionsTest = manager.sortVoices(testVoices, {
+    by: "languages",
+    preferredLanguages: ["en-CA", "fr-BE", "fr-FR"] // Inferred region should come first
+  });
+
+  // Should respect the exact order of regional preferences
+  t.is(prioritizedRegionsTest[0].language, "en-CA", "First explicit preference should be en-CA");
+  t.is(prioritizedRegionsTest[1].language, "en-GB", "UK English should come second");
+  t.is(prioritizedRegionsTest[2].language, "en-US", "US English should come third");
+  t.is(prioritizedRegionsTest[3].language, "fr-CA", "Inferred French Canadian should come fourth");
+  t.is(prioritizedRegionsTest[4].language, "fr-BE", "French Belgian should come fifth");
+  t.is(prioritizedRegionsTest[5].language, "fr-FR", "French French should come sixth");
+
+  // Test 5: Empty/undefined preferred languages (should sort alphabetically)
   const emptyPreferred = manager.sortVoices(testVoices, { 
     by: "languages",
     preferredLanguages: [] 

--- a/test/WebSpeechVoiceManager/sortVoices.test.ts
+++ b/test/WebSpeechVoiceManager/sortVoices.test.ts
@@ -90,14 +90,14 @@ testWithContext("sortVoices: sorts by language", (t: ExecutionContext<TestContex
   ];
   
   // Test ascending order
-  const sortedAsc = manager.sortVoices(testVoices, { by: "language", order: "asc" });
+  const sortedAsc = manager.sortVoices(testVoices, { by: "languages", order: "asc" });
   t.is(sortedAsc[0].language, "de-DE");
   t.is(sortedAsc[1].language, "en-US");
   t.is(sortedAsc[2].language, "es-ES");
   t.is(sortedAsc[3].language, "fr-FR");
   
   // Test descending order
-  const sortedDesc = manager.sortVoices(testVoices, { by: "language", order: "desc" });
+  const sortedDesc = manager.sortVoices(testVoices, { by: "languages", order: "desc" });
   t.is(sortedDesc[0].language, "fr-FR");
   t.is(sortedDesc[1].language, "es-ES");
   t.is(sortedDesc[2].language, "en-US");
@@ -174,7 +174,7 @@ testWithContext("sortVoices: sorts by preferred languages with region inference"
 
   // Test 1: Basic language code should use default region
   const defaultRegionTest = manager.sortVoices(testVoices, {
-    by: "language",
+    by: "languages",
     preferredLanguages: ["fr"]  // Should use default region (fr-FR)
   });
 
@@ -185,7 +185,7 @@ testWithContext("sortVoices: sorts by preferred languages with region inference"
 
   // Test 2: Region inference from other languages
   const inferredRegionTest = manager.sortVoices(testVoices, {
-    by: "language",
+    by: "languages",
     preferredLanguages: ["fr", "en-CA"]  // Should infer fr-CA as preferred French
   });
 
@@ -196,7 +196,7 @@ testWithContext("sortVoices: sorts by preferred languages with region inference"
 
   // Test 3: Multiple regional preferences
   const multipleRegionsTest = manager.sortVoices(testVoices, {
-    by: "language",
+    by: "languages",
     preferredLanguages: ["fr-BE", "fr-CA", "es"]  // Explicit regional preferences
   });
 
@@ -209,7 +209,7 @@ testWithContext("sortVoices: sorts by preferred languages with region inference"
 
   // Test 4: Empty/undefined preferred languages (should sort alphabetically)
   const emptyPreferred = manager.sortVoices(testVoices, { 
-    by: "language",
+    by: "languages",
     preferredLanguages: [] 
   });
   t.is(emptyPreferred[0].language, "de-DE");

--- a/test/WebSpeechVoiceManager/sortVoices.test.ts
+++ b/test/WebSpeechVoiceManager/sortVoices.test.ts
@@ -239,28 +239,27 @@ testWithContext("sortVoices: sorts by region with preferred languages", (t: Exec
   // Test with preferred languages that include regions
   const sorted = manager.sortVoices(testVoices, { 
     by: "region",
-    preferredLanguages: ["en-CA", "fr-CA", "en"] // Prefer Canadian English, then Canadian French, then any English
+    preferredLanguages: ["en-CA", "fr-CA", "fr-FR"] // Prefer Canadian English, then Canadian French, then French French, then all other languages
   });
   
   // Verify order:
   // 1. en-CA (exact match for first preferred)
   // 2. fr-CA (exact match for second preferred)
-  // 3. en-US (language match for third preferred)
-  // 4. en-GB (language match for third preferred)
-  // 5. en-AU (language match for third preferred)
-  // 6. fr-FR (no match, should come last)
+  // 3. fr-FR (language match for third preferred)
+  // 4. en-AU (alphabetical order)
+  // 5. en-GB (alphabetical order)
+  // 6. en-US (alphabetical order)
   t.is(sorted[0].language, "en-CA", "en-CA should be first (exact match)");
   t.is(sorted[1].language, "fr-CA", "fr-CA should be second (exact match)");
+  t.is(sorted[2].language, "fr-FR", "fr-FR should be third (language match)");
   
   // The remaining English variants should be in their natural order
-  const remainingEnglish = sorted.slice(2, 5).map(v => v.language);
+  const remainingEnglish = sorted.slice(3, 6).map(v => v.language);
   t.true(
-    ["en-US", "en-GB", "en-AU"].every(lang => remainingEnglish.includes(lang)),
+    ["en-AU", "en-GB", "en-US"].every(lang => remainingEnglish.includes(lang)),
     "Should include all English variants after exact matches"
   );
-  
-  t.is(sorted[5].language, "fr-FR", "fr-FR should be last (no match)");
-  
+    
   // Test with preferred languages that don't match any regions
   const noMatches = manager.sortVoices(testVoices, {
     by: "region",

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Test-only helper to get default region from JSON
+ * This file is only used in tests and never exposed in the main codebase
+ */
+export function getDefaultRegion(language: string): string {
+  const jsonPath = join(__dirname, `../json/${language}.json`);
+  const langData = JSON.parse(readFileSync(jsonPath, "utf-8"));
+  return langData.defaultRegion;
+}


### PR DESCRIPTION
This resolves #26 

It introduces a new helper whose purpose is to process arrays of BCP-47 codes, list all explicit regions in the array for each language, infer implicit regions e.g. `en-CA` →  `fr-CA` from what it can find in JSON data, and finally fall back to the default region from this same JSON data. 

Prioritisation from the original array is obviously kept AS-IS, it is only refined based on what it can find in the array.
