### PR TITLE
Improve ChromeOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,3 +416,49 @@ type ReadiumSpeechPlaybackEvent = {
 ```typescript
 type ReadiumSpeechPlaybackState = "playing" | "paused" | "idle" | "loading" | "ready";
 ```
+
+## Development
+
+We are trying to use a test-driven development approach as much as possible, where we write tests before implementing the code. Currently, this is true for the `WebSpeechVoiceManager` class as it deals primarily with voice selection and management, where mocking is straightforward.
+
+The playback logic is more complex and may not be suitable for this approach yet, as it involves more intricate state management and user interactions that is difficult to handle through mock objects, especially as browsers vary significantly in their implementation of the Web Speech API.
+
+### Building the Library
+
+To build the library:
+```bash
+npm run build
+```
+
+This will compile the TypeScript code and generate the following outputs in the `build/` directory:
+- `index.js` (ES modules)
+- `index.cjs` (CommonJS)
+- TypeScript type definitions
+
+### Running Demos Locally
+
+The project includes two demo applications that can be served locally:
+
+1. Start the local development server:
+   ```bash
+   npm run serve
+   ```
+
+2. Open your browser to:
+   - [Voice selection demo](http://localhost:8080/demo)
+   - [In-context reading demo](http://localhost:8080/demo/article)
+
+### ChromeOS Debugging
+
+For ChromeOS development, the project includes a debug mode that mocks the Web Speech API with the set of voices exported from the ChromeOS browser:
+
+1. Open the debug page: http://localhost:8080/debug
+
+2. The debug page loads mock voices from a json file which contains a snapshot of ChromeOS voices.
+
+### Running Tests
+
+To run the test suite for `WebSpeechVoiceManager`:
+```bash
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ Creates and initializes a new WebSpeechVoiceManager instance. This static factor
 - `interval`: Interval in milliseconds between voice loading checks (default: 100ms)
 - Returns: Promise that resolves with a new WebSpeechVoiceManager instance
 
-#### Get Available Voices
+#### Get filtered Voices
+
+By default, the instance keeps all voices in memory. You can filter them using the `getVoices` method with optional filter criteria and use this array instead.
 
 ```typescript
 voiceManager.getVoices(options?: VoiceFilterOptions): ReadiumSpeechVoice[]
@@ -163,6 +165,16 @@ interface VoiceFilterOptions {
   excludeVeryLowQuality?: boolean;  // Exclude very low quality voices, true by default
 }
 ```
+
+#### Get Languages and Regions
+
+```typescript
+voiceManager.getLanguages(localization?: string, filterOptions?: VoiceFilterOptions, voices?: ReadiumSpeechVoice[]): { code: string; label: string; count: number }[]
+
+voiceManager.getRegions(localization?: string, filterOptions?: VoiceFilterOptions, voices?: ReadiumSpeechVoice[]): { code: string; label: string; count: number }[]
+```
+
+Returns arrays of languages and regions with their display names and voice counts. Both methods preserve the order of first occurrence when custom voices are provided.
 
 #### Get Default Voice
 
@@ -192,15 +204,15 @@ The selection algorithm:
 #### Filter Voices
 
 ```typescript
-voiceManager.filterVoices(voices: ReadiumSpeechVoice[], options: VoiceFilterOptions): ReadiumSpeechVoice[]
+voiceManager.filterVoices(options: VoiceFilterOptions, voices?: ReadiumSpeechVoice[]): ReadiumSpeechVoice[]
 ```
 
-Filters voices based on the specified criteria.
+Filters voices based on the specified criteria. If no voices are provided, it filters the instance's internal voice list.
 
 #### Group Voices
 
 ```typescript
-voiceManager.groupVoices(voices: ReadiumSpeechVoice[], groupBy: "languages" | "region" | "gender" | "quality" | "provider"): VoiceGroup
+voiceManager.groupVoices(groupBy: "languages" | "region" | "gender" | "quality" | "provider", voices?: ReadiumSpeechVoice[]): VoiceGroup
 ```
 
 Organizes voices into groups based on the specified criteria. The available grouping options are:
@@ -210,6 +222,8 @@ Organizes voices into groups based on the specified criteria. The available grou
 - `"gender"`: Groups voices by gender
 - `"quality"`: Groups voices by quality level
 - `"provider"`: Groups voices by their provider
+
+If no voices are provided, it groups the instance's internal voice list.
 
 #### Sort Voices
 
@@ -222,31 +236,30 @@ If you need more control over the sorting process, you can implement and apply y
 Sort voices from highest to lowest quality:
 
 ```typescript
-const sortedVoices = voiceManager.sortVoicesByQuality(voices);
+voiceManager.sortVoicesByQuality(voices?: ReadiumSpeechVoice[]);
 // Returns: [veryHigh, high, normal, low, veryLow, null]
 ```
+
+If no voices are provided, it sorts the instance's internal voice list.
 
 ##### 2. Sort by Language
 
 Prioritize specific languages while maintaining JSON data’s quality order within each language group:
 
 ```typescript
-// Basic usage
-const sortedByLanguage = voiceManager.sortVoicesByLanguages(voices);
-
-// With preferred languages first
-const preferredFirst = voiceManager.sortVoicesByLanguages(voices, ["fr", "en"]);
-// Returns: [fr voices, en voices, other languages voices...]
+voiceManager.sortVoicesByLanguages(preferredLanguages?: string[], voices?: ReadiumSpeechVoice[]);
+// Returns: [preferred languages voices, other languages voices...]
 ```
+
+If no voices are provided, it sorts the instance's internal voice list.
 
 ##### 3. Sort by Region
 
 Sort voices by preferred languages and regions, while maintaining JSON data’s quality order within each region group:
 
 ```typescript
-// With preferred regions
-const preferredRegions = voiceManager.sortVoicesByRegions(voices, ["fr-FR", "en-US"]);
-// Returns: [fr-FR voices, other fr regions voices, en-US voices, other en regions voices, other regions voices...]
+voiceManager.sortVoicesByRegions(preferredLanguages?: string[], voices?: ReadiumSpeechVoice[]);
+// Returns: [languages in preferred then alphabetical order → regions: preferred regions → default region → alphabetical regions → voice quality within each region]
 ```
 
 ### Testing

--- a/debug/index.html
+++ b/debug/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Readium Speech Debug</title>
+  <link rel="stylesheet" href="../demo/styles.css">
+</head>
+<body>
+  <h1>Readium Speech Debug</h1>
+
+  <p>This page uses mock voices to simulate Chrome OS. More sets could be added in the future for additional platforms. Do not expect playback to work in this page.</p>
+  
+  <div class="control-panel">
+    <div class="form-group">
+      <label for="language-select">Language:</label>
+      <select id="language-select">
+        <option value="" disabled selected>Select a language</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <label for="voice-select">Voice:</label>
+      <select id="voice-select" disabled>
+        <option value="" disabled selected>Select a voice</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <div class="test-utterance-container">
+        <div class="test-utterance-input">
+          <label for="test-utterance">Test Utterance:</label>
+          <input type="text" id="test-utterance" placeholder="Load sample text or type your own">
+        </div>
+        <div class="test-utterance-button">
+          <button id="test-utterance-btn" disabled>Play Test Utterance</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <details class="voice-details">
+      <summary>Voice Details</summary>
+      <div id="voice-properties" class="voice-properties">
+        <p>Select a voice to see its properties</p>
+      </div>
+      </details>
+    </div>
+
+    <fieldset class="filter-section">
+      <legend>Filters</legend>
+      <div class="form-group">
+        <label for="gender-select">Gender:</label>
+        <select id="gender-select">
+          <option value="all" selected>All</option>
+          <option value="male">Male</option>
+          <option value="female">Female</option>
+          <option value="neutral">Neutral</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label for="source-select">Source:</label>
+        <select id="source-select">
+          <option value="all" selected>All</option>
+          <option value="json">JSON</option>
+          <option value="browser">Browser</option>
+        </select>
+      </div>
+
+      <div class="checkbox-group">
+        <input type="checkbox" id="offline-only">
+        <label for="offline-only">Show only offline voices</label>
+      </div>
+    </fieldset>
+  </div>
+
+  <div class="content-container">
+    <div class="controls-group">
+      <div class="playback-controls">
+        <button id="play-pause-btn" class="play-state" disabled>▶️ Play</button>
+        <button id="stop-btn" class="stop" disabled>⏹️ Stop</button>
+        <button id="prev-utterance-btn" class="nav" disabled>⏮️ Previous</button>
+        <button id="next-utterance-btn" class="nav" disabled>⏭️ Next</button>
+      </div>
+
+      <div class="jump-controls">
+        <input type="number" id="utterance-index" min="1" value="1" disabled>
+        <span>of <span id="total-utterances">-</span></span>
+        <button id="jump-to-btn" class="jump-btn" disabled>Jump To</button>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <div id="sample-text" class="text-display">
+        Select a language to load sample text...
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <details class="dev-tools">
+      <summary>Developer Tools</summary>
+      <div class="dev-tools-items">
+        <button id="download-voices-btn" class="download-btn">Download All Browser Voices as JSON</button>
+      </div>
+    </details>
+  </div>
+
+  <!-- Load mock voices BEFORE the demo script -->
+  <script src="../debug/mock-voices.js"></script>
+
+  <script type="module" src="../demo/script.js"></script>
+</body>
+</html>

--- a/debug/mock-voices.js
+++ b/debug/mock-voices.js
@@ -1,0 +1,114 @@
+// Mock window.speechSynthesis.getVoices() for ChromeOS debugging
+// Load this script before the main speech library
+
+(async function() {
+  // Load the mock voices data
+  const response = await fetch("../debug/speech-voices-2026-01-09.json");
+  const mockData = await response.json();
+  
+  // Convert JSON voices to SpeechSynthesisVoice objects
+  const mockVoices = mockData.voices.map(voice => ({
+    voiceURI: voice.voiceURI,
+    name: voice.name,
+    lang: voice.lang,
+    localService: voice.localService,
+    default: voice.default
+  }));
+  
+  // Mock SpeechSynthesisUtterance constructor
+  class MockSpeechSynthesisUtterance {
+    constructor(text) {
+      this.text = text;
+      this.voice = null;
+      this.lang = null;
+      this.pitch = 1;
+      this.rate = 1;
+      this.volume = 1;
+      this.onstart = null;
+      this.onend = null;
+      this.onerror = null;
+      this.onboundary = null;
+      this.onmark = null;
+      this.onpause = null;
+      this.onresume = null;
+    }
+  }
+  
+  // Replace SpeechSynthesisUtterance constructor
+  if (typeof window !== "undefined") {
+    window.SpeechSynthesisUtterance = MockSpeechSynthesisUtterance;
+  }
+  
+  // Create mock speechSynthesis object
+  const mockSpeechSynthesis = {
+    getVoices: () => mockVoices,
+    speak: (utterance) => {
+      console.log("Mock speak:", utterance.text);
+      
+      // Store current utterance for state tracking
+      mockSpeechSynthesis.speaking = true;
+      mockSpeechSynthesis.pending = false;
+      
+      // Trigger events after a short delay to simulate real speech
+      setTimeout(() => {
+        if (utterance.onstart) utterance.onstart();
+        
+        // Simulate word boundaries (optional, but helpful for testing)
+        const words = utterance.text.split(" ");
+        let charIndex = 0;
+        words.forEach((word, i) => {
+          setTimeout(() => {
+            if (utterance.onboundary) {
+              utterance.onboundary({
+                name: "word",
+                charIndex: charIndex,
+                charLength: word.length
+              });
+            }
+            charIndex += word.length + 1; // +1 for space
+          }, i * 200); // 200ms per word
+        });
+        
+        // End after total duration
+        const totalDuration = words.length * 200 + 500; // 500ms buffer
+        setTimeout(() => {
+          mockSpeechSynthesis.speaking = false;
+          if (utterance.onend) utterance.onend();
+        }, totalDuration);
+      }, 100);
+    },
+    cancel: () => {
+      console.log("Mock cancel");
+      mockSpeechSynthesis.speaking = false;
+      mockSpeechSynthesis.pending = false;
+    },
+    pause: () => {
+      console.log("Mock pause");
+      mockSpeechSynthesis.paused = true;
+    },
+    resume: () => {
+      console.log("Mock resume");
+      mockSpeechSynthesis.paused = false;
+    },
+    speaking: false,
+    paused: false,
+    pending: false,
+    onvoiceschanged: null
+  };
+  
+  // Replace the real speechSynthesis with our mock
+  Object.defineProperty(window, "speechSynthesis", {
+    value: mockSpeechSynthesis,
+    writable: true,
+    configurable: true
+  });
+  
+  // Trigger onvoiceschanged to simulate voice loading
+  setTimeout(() => {
+    if (mockSpeechSynthesis.onvoiceschanged) {
+      mockSpeechSynthesis.onvoiceschanged();
+    }
+  }, 100);
+  
+  console.log(`Loaded ${mockVoices.length} mock voices for ChromeOS debugging`);
+})();

--- a/debug/speech-voices-2026-01-09.json
+++ b/debug/speech-voices-2026-01-09.json
@@ -1,0 +1,3823 @@
+{
+  "metadata": {
+    "timestamp": "2026-01-09T16:17:10.226Z",
+    "voicesCount": 545
+  },
+  "voices": [
+    {
+      "voiceURI": "Chrome OS US English 1",
+      "name": "Chrome OS US English 1",
+      "lang": "en-US",
+      "localService": true,
+      "default": true
+    },
+    {
+      "voiceURI": "Chrome OS US English 2",
+      "name": "Chrome OS US English 2",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS US English 3",
+      "name": "Chrome OS US English 3",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS US English 4",
+      "name": "Chrome OS US English 4",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS US English 5",
+      "name": "Chrome OS US English 5",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS US English 6",
+      "name": "Chrome OS US English 6",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS US English 7",
+      "name": "Chrome OS US English 7",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS US English 8",
+      "name": "Chrome OS US English 8",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS हिन्दी 1",
+      "name": "Chrome OS हिन्दी 1",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS हिन्दी 2",
+      "name": "Chrome OS हिन्दी 2",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS हिन्दी  3",
+      "name": "Chrome OS हिन्दी  3",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS हिन्दी  4",
+      "name": "Chrome OS हिन्दी  4",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS हिन्दी  5",
+      "name": "Chrome OS हिन्दी  5",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS français 1",
+      "name": "Chrome OS français 1",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS français 2",
+      "name": "Chrome OS français 2",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS français 3",
+      "name": "Chrome OS français 3",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS français 4",
+      "name": "Chrome OS français 4",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS français 5",
+      "name": "Chrome OS français 5",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS español 1",
+      "name": "Chrome OS español 1",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS español 2",
+      "name": "Chrome OS español 2",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS español 3",
+      "name": "Chrome OS español 3",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS español 4",
+      "name": "Chrome OS español 4",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS español 5",
+      "name": "Chrome OS español 5",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS Nederlands 1",
+      "name": "Chrome OS Nederlands 1",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS Nederlands 2",
+      "name": "Chrome OS Nederlands 2",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS Nederlands 3",
+      "name": "Chrome OS Nederlands 3",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS Nederlands 4",
+      "name": "Chrome OS Nederlands 4",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS Nederlands 5",
+      "name": "Chrome OS Nederlands 5",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS 日本語 1",
+      "name": "Chrome OS 日本語 1",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS 日本語 2",
+      "name": "Chrome OS 日本語 2",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS 日本語 3",
+      "name": "Chrome OS 日本語 3",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Chrome OS 日本語 4",
+      "name": "Chrome OS 日本語 4",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Google US English 1 (Natural)",
+      "name": "Google US English 1 (Natural)",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Google US English 2 (Natural)",
+      "name": "Google US English 2 (Natural)",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Google US English 3 (Natural)",
+      "name": "Google US English 3 (Natural)",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Google US English 4 (Natural)",
+      "name": "Google US English 4 (Natural)",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Google US English 5 (Natural)",
+      "name": "Google US English 5 (Natural)",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Google US English 6 (Natural)",
+      "name": "Google US English 6 (Natural)",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Google US English 7 (Natural)",
+      "name": "Google US English 7 (Natural)",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-msd-local",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-msd-local",
+      "lang": "ms-MY",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gba-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gba-local",
+      "lang": "en-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iol-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iol-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-kda-local",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-kda-local",
+      "lang": "it-IT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google as-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google as-in-x-end-local",
+      "lang": "as-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google as-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google as-IN-language",
+      "lang": "as-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-frc-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-frc-local",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-oda-local",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-oda-local",
+      "lang": "pl-PL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-be-x-bec-local",
+      "name": "Android Speech Recognition and Synthesis from Google nl-be-x-bec-local",
+      "lang": "nl-BE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-pmj-local",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-pmj-local",
+      "lang": "pt-PT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-lfs-local",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-lfs-local",
+      "lang": "sv-SE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-NO-language",
+      "name": "Android Speech Recognition and Synthesis from Google nb-NO-language",
+      "lang": "nb-NO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-arz-local",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-arz-local",
+      "lang": "ar",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-cad-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-cad-local",
+      "lang": "fr-CA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-tpf-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-tpf-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-htm-local",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-htm-local",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cy-gb-x-cyf-local",
+      "name": "Android Speech Recognition and Synthesis from Google cy-gb-x-cyf-local",
+      "lang": "cy-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-cce-local",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-cce-local",
+      "lang": "zh-CN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-jfb-local",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-jfb-local",
+      "lang": "pt-PT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-SE-language",
+      "name": "Android Speech Recognition and Synthesis from Google sv-SE-language",
+      "lang": "sv-SE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruc-local",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruc-local",
+      "lang": "ru-RU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-ard-local",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-ard-local",
+      "lang": "ar",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-mse-local",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-mse-local",
+      "lang": "ms-MY",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-NL-language",
+      "name": "Android Speech Recognition and Synthesis from Google nl-NL-language",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sl-SI-language",
+      "name": "Android Speech Recognition and Synthesis from Google sl-SI-language",
+      "lang": "sl-SI",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-tfs-local",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-tfs-local",
+      "lang": "nb-NO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sw-ke-language",
+      "name": "Android Speech Recognition and Synthesis from Google sw-ke-language",
+      "lang": "sw-KE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruf-local",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruf-local",
+      "lang": "ru-RU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-sfp-local",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-sfp-local",
+      "lang": "da-DK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-jac-local",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-jac-local",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-auc-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-auc-local",
+      "lang": "en-AU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-US-language",
+      "name": "Android Speech Recognition and Synthesis from Google es-US-language",
+      "lang": "es-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-bd-x-ban-local",
+      "name": "Android Speech Recognition and Synthesis from Google bn-bd-x-ban-local",
+      "lang": "bn-BD",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google zh-TW-language",
+      "name": "Android Speech Recognition and Synthesis from Google zh-TW-language",
+      "lang": "zh-TW",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google mni-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google mni-in-x-end-local",
+      "lang": "mni-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-br-x-ptd-local",
+      "name": "Android Speech Recognition and Synthesis from Google pt-br-x-ptd-local",
+      "lang": "pt-BR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eec-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eec-local",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hu-hu-x-kfl-local",
+      "name": "Android Speech Recognition and Synthesis from Google hu-hu-x-kfl-local",
+      "lang": "hu-HU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-caa-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-caa-local",
+      "lang": "fr-CA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-tpc-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-tpc-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bnf-local",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bnf-local",
+      "lang": "bn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google kok-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google kok-IN-language",
+      "lang": "kok-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google jv-ID-language",
+      "name": "Android Speech Recognition and Synthesis from Google jv-ID-language",
+      "lang": "jv-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pad-local",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pad-local",
+      "lang": "pa-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ml-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google ml-IN-language",
+      "lang": "ml-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-ena-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-ena-local",
+      "lang": "en-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cy-GB-language",
+      "name": "Android Speech Recognition and Synthesis from Google cy-GB-language",
+      "lang": "cy-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-deb-local",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-deb-local",
+      "lang": "de-DE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google uk-ua-x-hfd-local",
+      "name": "Android Speech Recognition and Synthesis from Google uk-ua-x-hfd-local",
+      "lang": "uk-UA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eee-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eee-local",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-hec-local",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-hec-local",
+      "lang": "iw-IL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-BE-language",
+      "name": "Android Speech Recognition and Synthesis from Google nl-BE-language",
+      "lang": "nl-BE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccc-local",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccc-local",
+      "lang": "zh-CN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-ID-language",
+      "name": "Android Speech Recognition and Synthesis from Google id-ID-language",
+      "lang": "in-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctd-local",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctd-local",
+      "lang": "zh-TW",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iog-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iog-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-sfs-local",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-sfs-local",
+      "lang": "pt-PT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctc-local",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctc-local",
+      "lang": "zh-TW",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-rjs-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-rjs-local",
+      "lang": "en-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-kob-local",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-kob-local",
+      "lang": "ko-KR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vie-local",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vie-local",
+      "lang": "vi-VN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-PL-language",
+      "name": "Android Speech Recognition and Synthesis from Google pl-PL-language",
+      "lang": "pl-PL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google km-kh-x-khm-local",
+      "name": "Android Speech Recognition and Synthesis from Google km-kh-x-khm-local",
+      "lang": "km-KH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-idd-local",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-idd-local",
+      "lang": "in-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google doi-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google doi-in-x-end-local",
+      "lang": "doi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-msc-local",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-msc-local",
+      "lang": "ms-MY",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ro-ro-x-vfv-local",
+      "name": "Android Speech Recognition and Synthesis from Google ro-ro-x-vfv-local",
+      "lang": "ro-RO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bg-bg-language",
+      "name": "Android Speech Recognition and Synthesis from Google bg-bg-language",
+      "lang": "bg-BG",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bs-ba-x-bsm-local",
+      "name": "Android Speech Recognition and Synthesis from Google bs-ba-x-bsm-local",
+      "lang": "bs-BA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google jv-id-x-jvf-local",
+      "name": "Android Speech Recognition and Synthesis from Google jv-id-x-jvf-local",
+      "lang": "jv-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-PT-language",
+      "name": "Android Speech Recognition and Synthesis from Google pt-PT-language",
+      "lang": "pt-PT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google lt-lt-x-amc-local",
+      "name": "Android Speech Recognition and Synthesis from Google lt-lt-x-amc-local",
+      "lang": "lt-LT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-br-x-pte-local",
+      "name": "Android Speech Recognition and Synthesis from Google pt-br-x-pte-local",
+      "lang": "pt-BR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google gu-in-x-gum-local",
+      "name": "Android Speech Recognition and Synthesis from Google gu-in-x-gum-local",
+      "lang": "gu-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sat-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google sat-IN-language",
+      "lang": "sat-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-sfg-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-sfg-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-PH-language",
+      "name": "Android Speech Recognition and Synthesis from Google fil-PH-language",
+      "lang": "fil-PH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-ene-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-ene-local",
+      "lang": "en-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-BR-language",
+      "name": "Android Speech Recognition and Synthesis from Google pt-BR-language",
+      "lang": "pt-BR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ca-es-x-caf-local",
+      "name": "Android Speech Recognition and Synthesis from Google ca-es-x-caf-local",
+      "lang": "ca-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-language",
+      "name": "Android Speech Recognition and Synthesis from Google ar-language",
+      "lang": "ar",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-TR-language",
+      "name": "Android Speech Recognition and Synthesis from Google tr-TR-language",
+      "lang": "tr-TR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbg-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbg-local",
+      "lang": "en-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-fie-local",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-fie-local",
+      "lang": "fil-PH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-afp-local",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-afp-local",
+      "lang": "sv-SE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ta-in-x-tac-local",
+      "name": "Android Speech Recognition and Synthesis from Google ta-in-x-tac-local",
+      "lang": "ta-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cs-CZ-language",
+      "name": "Android Speech Recognition and Synthesis from Google cs-CZ-language",
+      "lang": "cs-CZ",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google si-lk-x-sin-local",
+      "name": "Android Speech Recognition and Synthesis from Google si-lk-x-sin-local",
+      "lang": "si-LK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-dea-local",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-dea-local",
+      "lang": "de-DE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iob-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iob-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google th-th-x-mol-local",
+      "name": "Android Speech Recognition and Synthesis from Google th-th-x-mol-local",
+      "lang": "th-TH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-tfb-local",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-tfb-local",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google km-KH-language",
+      "name": "Android Speech Recognition and Synthesis from Google km-KH-language",
+      "lang": "km-KH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bin-local",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bin-local",
+      "lang": "bn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bs-ba-language",
+      "name": "Android Speech Recognition and Synthesis from Google bs-ba-language",
+      "lang": "bs-BA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pac-local",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pac-local",
+      "lang": "pa-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-RU-language",
+      "name": "Android Speech Recognition and Synthesis from Google ru-RU-language",
+      "lang": "ru-RU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbd-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbd-local",
+      "lang": "en-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-bmg-local",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-bmg-local",
+      "lang": "pl-PL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-ama-local",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-ama-local",
+      "lang": "tr-TR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-cfs-local",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-cfs-local",
+      "lang": "tr-TR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sd-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google sd-in-x-end-local",
+      "lang": "sd-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google kn-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google kn-IN-language",
+      "lang": "kn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-jmn-local",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-jmn-local",
+      "lang": "pt-PT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-ide-local",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-ide-local",
+      "lang": "in-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google et-ee-x-tms-local",
+      "name": "Android Speech Recognition and Synthesis from Google et-ee-x-tms-local",
+      "lang": "et-EE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google en-IN-language",
+      "lang": "en-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google kn-in-x-knf-local",
+      "name": "Android Speech Recognition and Synthesis from Google kn-in-x-knf-local",
+      "lang": "kn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-esd-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-esd-local",
+      "lang": "es-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google te-in-x-tef-local",
+      "name": "Android Speech Recognition and Synthesis from Google te-in-x-tef-local",
+      "lang": "te-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hic-local",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hic-local",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fi-fi-x-afi-local",
+      "name": "Android Speech Recognition and Synthesis from Google fi-fi-x-afi-local",
+      "lang": "fi-FI",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ml-in-x-mlm-local",
+      "name": "Android Speech Recognition and Synthesis from Google ml-in-x-mlm-local",
+      "lang": "ml-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sw-ke-x-swm-local",
+      "name": "Android Speech Recognition and Synthesis from Google sw-ke-x-swm-local",
+      "lang": "sw-KE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google el-GR-language",
+      "name": "Android Speech Recognition and Synthesis from Google el-GR-language",
+      "lang": "el-GR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google is-is-x-isf-local",
+      "name": "Android Speech Recognition and Synthesis from Google is-is-x-isf-local",
+      "lang": "is-IS",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hie-local",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hie-local",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-dmc-local",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-dmc-local",
+      "lang": "sv-SE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-lfc-local",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-lfc-local",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sq-al-x-sqm-local",
+      "name": "Android Speech Recognition and Synthesis from Google sq-al-x-sqm-local",
+      "lang": "sq-AL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-language",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-language",
+      "lang": "iw-IL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-arc-local",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-arc-local",
+      "lang": "ar",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google mr-in-x-mrf-local",
+      "name": "Android Speech Recognition and Synthesis from Google mr-in-x-mrf-local",
+      "lang": "mr-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google mai-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google mai-IN-language",
+      "lang": "mai-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eef-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eef-local",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-kod-local",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-kod-local",
+      "lang": "ko-KR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-frd-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-frd-local",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ta-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google ta-IN-language",
+      "lang": "ta-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google kn-in-x-knm-local",
+      "name": "Android Speech Recognition and Synthesis from Google kn-in-x-knm-local",
+      "lang": "kn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ta-in-x-tad-local",
+      "name": "Android Speech Recognition and Synthesis from Google ta-in-x-tad-local",
+      "lang": "ta-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bnm-local",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bnm-local",
+      "lang": "bn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cs-cz-x-jfs-local",
+      "name": "Android Speech Recognition and Synthesis from Google cs-cz-x-jfs-local",
+      "lang": "cs-CZ",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-cmh-local",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-cmh-local",
+      "lang": "sv-SE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-DE-language",
+      "name": "Android Speech Recognition and Synthesis from Google de-DE-language",
+      "lang": "de-DE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-tmg-local",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-tmg-local",
+      "lang": "nb-NO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fi-FI-language",
+      "name": "Android Speech Recognition and Synthesis from Google fi-FI-language",
+      "lang": "fi-FI",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sl-si-x-frm-local",
+      "name": "Android Speech Recognition and Synthesis from Google sl-si-x-frm-local",
+      "lang": "sl-SI",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-jad-local",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-jad-local",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vid-local",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vid-local",
+      "lang": "vi-VN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-nfh-local",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-nfh-local",
+      "lang": "de-DE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ur-pk-x-urm-local",
+      "name": "Android Speech Recognition and Synthesis from Google ur-pk-x-urm-local",
+      "lang": "ur-PK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-end-local",
+      "lang": "en-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbb-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbb-local",
+      "lang": "en-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eea-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eea-local",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccd-local",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccd-local",
+      "lang": "zh-CN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-kfm-local",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-kfm-local",
+      "lang": "da-DK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-heb-local",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-heb-local",
+      "lang": "iw-IL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google lv-lv-x-imr-local",
+      "name": "Android Speech Recognition and Synthesis from Google lv-lv-x-imr-local",
+      "lang": "lv-LV",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-dfz-local",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-dfz-local",
+      "lang": "in-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-ism-local",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-ism-local",
+      "lang": "ko-KR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google gu-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google gu-IN-language",
+      "lang": "gu-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sk-SK-language",
+      "name": "Android Speech Recognition and Synthesis from Google sk-SK-language",
+      "lang": "sk-SK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google or-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google or-IN-language",
+      "lang": "or-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google or-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google or-in-x-end-local",
+      "lang": "or-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-cac-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-cac-local",
+      "lang": "fr-CA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google el-gr-x-vfz-local",
+      "name": "Android Speech Recognition and Synthesis from Google el-gr-x-vfz-local",
+      "lang": "el-GR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-itb-local",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-itb-local",
+      "lang": "it-IT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-msg-local",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-msg-local",
+      "lang": "ms-MY",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-vfb-local",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-vfb-local",
+      "lang": "da-DK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuc-local",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuc-local",
+      "lang": "yue-HK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuf-local",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuf-local",
+      "lang": "yue-HK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-vlf-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-vlf-local",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-dfc-local",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-dfc-local",
+      "lang": "ru-RU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google si-LK-language",
+      "name": "Android Speech Recognition and Synthesis from Google si-LK-language",
+      "lang": "si-LK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google brx-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google brx-IN-language",
+      "lang": "brx-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-aub-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-aub-local",
+      "lang": "en-AU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-rue-local",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-rue-local",
+      "lang": "ru-RU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google gu-in-x-guf-local",
+      "name": "Android Speech Recognition and Synthesis from Google gu-in-x-guf-local",
+      "lang": "gu-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-MY-language",
+      "name": "Android Speech Recognition and Synthesis from Google ms-MY-language",
+      "lang": "ms-MY",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-fid-local",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-fid-local",
+      "lang": "fil-PH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bnx-local",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bnx-local",
+      "lang": "bn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-deg-local",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-deg-local",
+      "lang": "de-DE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-mfm-local",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-mfm-local",
+      "lang": "tr-TR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ro-RO-language",
+      "name": "Android Speech Recognition and Synthesis from Google ro-RO-language",
+      "lang": "ro-RO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbc-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbc-local",
+      "lang": "en-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ne-NP-language",
+      "name": "Android Speech Recognition and Synthesis from Google ne-NP-language",
+      "lang": "ne-NP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-jar-local",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-jar-local",
+      "lang": "yue-HK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yue-local",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yue-local",
+      "lang": "yue-HK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-tw-x-cte-local",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-tw-x-cte-local",
+      "lang": "zh-TW",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-cfc-local",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-cfc-local",
+      "lang": "fil-PH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ne-np-x-nep-local",
+      "name": "Android Speech Recognition and Synthesis from Google ne-np-x-nep-local",
+      "lang": "ne-NP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-itc-local",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-itc-local",
+      "lang": "it-IT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-cfl-local",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-cfl-local",
+      "lang": "nb-NO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google su-ID-language",
+      "name": "Android Speech Recognition and Synthesis from Google su-ID-language",
+      "lang": "su-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google th-TH-language",
+      "name": "Android Speech Recognition and Synthesis from Google th-TH-language",
+      "lang": "th-TH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google zh-CN-language",
+      "name": "Android Speech Recognition and Synthesis from Google zh-CN-language",
+      "lang": "zh-CN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-itd-local",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-itd-local",
+      "lang": "it-IT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-aud-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-aud-local",
+      "lang": "en-AU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-AU-language",
+      "name": "Android Speech Recognition and Synthesis from Google en-AU-language",
+      "lang": "en-AU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hr-HR-language",
+      "name": "Android Speech Recognition and Synthesis from Google hr-HR-language",
+      "lang": "hr-HR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-JP-language",
+      "name": "Android Speech Recognition and Synthesis from Google ja-JP-language",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-FR-language",
+      "name": "Android Speech Recognition and Synthesis from Google fr-FR-language",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-frb-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-frb-local",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sr-rs-language",
+      "name": "Android Speech Recognition and Synthesis from Google sr-rs-language",
+      "lang": "sr-RS",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sa-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google sa-in-x-end-local",
+      "lang": "sa-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-rfj-local",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-rfj-local",
+      "lang": "nb-NO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-afb-local",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-afb-local",
+      "lang": "pl-PL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pag-local",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pag-local",
+      "lang": "pa-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-BD-language",
+      "name": "Android Speech Recognition and Synthesis from Google bn-BD-language",
+      "lang": "bn-BD",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vic-local",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vic-local",
+      "lang": "vi-VN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hr-hr-x-hra-local",
+      "name": "Android Speech Recognition and Synthesis from Google hr-hr-x-hra-local",
+      "lang": "hr-HR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-cmj-local",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-cmj-local",
+      "lang": "nb-NO",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-DK-language",
+      "name": "Android Speech Recognition and Synthesis from Google da-DK-language",
+      "lang": "da-DK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-hee-local",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-hee-local",
+      "lang": "iw-IL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google pa-IN-language",
+      "lang": "pa-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yud-local",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yud-local",
+      "lang": "yue-HK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ml-in-x-mlf-local",
+      "name": "Android Speech Recognition and Synthesis from Google ml-in-x-mlf-local",
+      "lang": "ml-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ks-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google ks-IN-language",
+      "lang": "ks-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-nmm-local",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-nmm-local",
+      "lang": "da-DK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google doi-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google doi-IN-language",
+      "lang": "doi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google kok-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google kok-in-x-end-local",
+      "lang": "kok-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google lv-LV-language",
+      "name": "Android Speech Recognition and Synthesis from Google lv-LV-language",
+      "lang": "lv-LV",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-be-x-bed-local",
+      "name": "Android Speech Recognition and Synthesis from Google nl-be-x-bed-local",
+      "lang": "nl-BE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-GB-language",
+      "name": "Android Speech Recognition and Synthesis from Google en-GB-language",
+      "lang": "en-GB",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hia-local",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hia-local",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ks-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google ks-in-x-end-local",
+      "lang": "ks-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-yfr-local",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-yfr-local",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-are-local",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-are-local",
+      "lang": "ar",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ca-ES-language",
+      "name": "Android Speech Recognition and Synthesis from Google ca-ES-language",
+      "lang": "ca-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google mr-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google mr-IN-language",
+      "lang": "mr-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google te-in-x-tem-local",
+      "name": "Android Speech Recognition and Synthesis from Google te-in-x-tem-local",
+      "lang": "te-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-rud-local",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-rud-local",
+      "lang": "ru-RU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-dma-local",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-dma-local",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google et-EE-language",
+      "name": "Android Speech Recognition and Synthesis from Google et-EE-language",
+      "lang": "et-EE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-KR-language",
+      "name": "Android Speech Recognition and Synthesis from Google ko-KR-language",
+      "lang": "ko-KR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bg-bg-x-ifk-local",
+      "name": "Android Speech Recognition and Synthesis from Google bg-bg-x-ifk-local",
+      "lang": "bg-BG",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-tmc-local",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-tmc-local",
+      "lang": "tr-TR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-NG-language",
+      "name": "Android Speech Recognition and Synthesis from Google en-NG-language",
+      "lang": "en-NG",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-enc-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-enc-local",
+      "lang": "en-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-aua-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-aua-local",
+      "lang": "en-AU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google te-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google te-IN-language",
+      "lang": "te-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-ES-language",
+      "name": "Android Speech Recognition and Synthesis from Google es-ES-language",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-bmh-local",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-bmh-local",
+      "lang": "nl-NL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ur-PK-language",
+      "name": "Android Speech Recognition and Synthesis from Google ur-PK-language",
+      "lang": "ur-PK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google is-is-language",
+      "name": "Android Speech Recognition and Synthesis from Google is-is-language",
+      "lang": "is-IS",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vif-local",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vif-local",
+      "lang": "vi-VN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-VN-language",
+      "name": "Android Speech Recognition and Synthesis from Google vi-VN-language",
+      "lang": "vi-VN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-esf-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-esf-local",
+      "lang": "es-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-sfb-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-sfb-local",
+      "lang": "es-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hid-local",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hid-local",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ur-pk-x-cfn-local",
+      "name": "Android Speech Recognition and Synthesis from Google ur-pk-x-cfn-local",
+      "lang": "ur-PK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-esc-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-esc-local",
+      "lang": "es-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-jmk-local",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-jmk-local",
+      "lang": "pl-PL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google mni-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google mni-IN-language",
+      "lang": "mni-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-CA-language",
+      "name": "Android Speech Recognition and Synthesis from Google fr-CA-language",
+      "lang": "fr-CA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-IT-language",
+      "name": "Android Speech Recognition and Synthesis from Google it-IT-language",
+      "lang": "it-IT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-zfg-local",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-zfg-local",
+      "lang": "pl-PL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-tpd-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-tpd-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iom-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iom-local",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-jab-local",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-jab-local",
+      "lang": "ja-JP",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-hed-local",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-hed-local",
+      "lang": "iw-IL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-br-x-afs-local",
+      "name": "Android Speech Recognition and Synthesis from Google pt-br-x-afs-local",
+      "lang": "pt-BR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google brx-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google brx-in-x-end-local",
+      "lang": "brx-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-fic-local",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-fic-local",
+      "lang": "fil-PH",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hr-hr-x-hrb-local",
+      "name": "Android Speech Recognition and Synthesis from Google hr-hr-x-hrb-local",
+      "lang": "hr-HR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ssa-local",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ssa-local",
+      "lang": "zh-CN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-cab-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-cab-local",
+      "lang": "fr-CA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google hi-IN-language",
+      "lang": "hi-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eed-local",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eed-local",
+      "lang": "es-ES",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-fra-local",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-fra-local",
+      "lang": "fr-FR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-gft-local",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-gft-local",
+      "lang": "vi-VN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hu-HU-language",
+      "name": "Android Speech Recognition and Synthesis from Google hu-HU-language",
+      "lang": "hu-HU",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google mai-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google mai-in-x-end-local",
+      "lang": "mai-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-idc-local",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-idc-local",
+      "lang": "in-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google lt-lt-language",
+      "name": "Android Speech Recognition and Synthesis from Google lt-lt-language",
+      "lang": "lt-LT",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-cfg-local",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-cfg-local",
+      "lang": "sv-SE",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google bn-IN-language",
+      "lang": "bn-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sa-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google sa-IN-language",
+      "lang": "sa-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-ng-x-tfn-local",
+      "name": "Android Speech Recognition and Synthesis from Google en-ng-x-tfn-local",
+      "lang": "en-NG",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-efu-local",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-efu-local",
+      "lang": "tr-TR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sat-in-x-end-local",
+      "name": "Android Speech Recognition and Synthesis from Google sat-in-x-end-local",
+      "lang": "sat-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-koc-local",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-koc-local",
+      "lang": "ko-KR",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-US-language",
+      "name": "Android Speech Recognition and Synthesis from Google en-US-language",
+      "lang": "en-US",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-HK-language",
+      "name": "Android Speech Recognition and Synthesis from Google yue-HK-language",
+      "lang": "yue-HK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pae-local",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pae-local",
+      "lang": "pa-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sk-sk-x-sfk-local",
+      "name": "Android Speech Recognition and Synthesis from Google sk-sk-x-sfk-local",
+      "lang": "sk-SK",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sq-al-language",
+      "name": "Android Speech Recognition and Synthesis from Google sq-al-language",
+      "lang": "sq-AL",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google su-id-x-suf-local",
+      "name": "Android Speech Recognition and Synthesis from Google su-id-x-suf-local",
+      "lang": "su-ID",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google uk-UA-language",
+      "name": "Android Speech Recognition and Synthesis from Google uk-UA-language",
+      "lang": "uk-UA",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sd-IN-language",
+      "name": "Android Speech Recognition and Synthesis from Google sd-IN-language",
+      "lang": "sd-IN",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctd-network",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctd-network",
+      "lang": "zh-TW",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google kn-in-x-knm-network",
+      "name": "Android Speech Recognition and Synthesis from Google kn-in-x-knm-network",
+      "lang": "kn-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbc-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbc-network",
+      "lang": "en-GB",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hu-hu-x-kfl-network",
+      "name": "Android Speech Recognition and Synthesis from Google hu-hu-x-kfl-network",
+      "lang": "hu-HU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-htm-network",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-htm-network",
+      "lang": "ja-JP",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hia-network",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hia-network",
+      "lang": "hi-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruc-network",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruc-network",
+      "lang": "ru-RU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google lt-lt-x-amc-network",
+      "name": "Android Speech Recognition and Synthesis from Google lt-lt-x-amc-network",
+      "lang": "lt-LT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-hed-network",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-hed-network",
+      "lang": "iw-IL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-aua-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-aua-network",
+      "lang": "en-AU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-jad-network",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-jad-network",
+      "lang": "ja-JP",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-sfp-network",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-sfp-network",
+      "lang": "da-DK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-be-x-bec-network",
+      "name": "Android Speech Recognition and Synthesis from Google nl-be-x-bec-network",
+      "lang": "nl-BE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sw-ke-x-swm-network",
+      "name": "Android Speech Recognition and Synthesis from Google sw-ke-x-swm-network",
+      "lang": "sw-KE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-afp-network",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-afp-network",
+      "lang": "sv-SE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-ng-x-tfn-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-ng-x-tfn-network",
+      "lang": "en-NG",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pag-network",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pag-network",
+      "lang": "pa-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-ene-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-ene-network",
+      "lang": "en-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-deb-network",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-deb-network",
+      "lang": "de-DE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-cmh-network",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-cmh-network",
+      "lang": "sv-SE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google si-lk-x-sin-network",
+      "name": "Android Speech Recognition and Synthesis from Google si-lk-x-sin-network",
+      "lang": "si-LK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-bmg-network",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-bmg-network",
+      "lang": "pl-PL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-kod-network",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-kod-network",
+      "lang": "ko-KR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-bd-x-ban-network",
+      "name": "Android Speech Recognition and Synthesis from Google bn-bd-x-ban-network",
+      "lang": "bn-BD",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-enc-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-enc-network",
+      "lang": "en-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-auc-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-auc-network",
+      "lang": "en-AU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sq-al-x-sqm-network",
+      "name": "Android Speech Recognition and Synthesis from Google sq-al-x-sqm-network",
+      "lang": "sq-AL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-ard-network",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-ard-network",
+      "lang": "ar",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccd-network",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccd-network",
+      "lang": "zh-CN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gba-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gba-network",
+      "lang": "en-GB",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-esf-network",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-esf-network",
+      "lang": "es-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hic-network",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hic-network",
+      "lang": "hi-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-cfs-network",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-cfs-network",
+      "lang": "tr-TR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuc-network",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuc-network",
+      "lang": "yue-HK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-jmk-network",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-jmk-network",
+      "lang": "pl-PL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vie-network",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vie-network",
+      "lang": "vi-VN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-dfz-network",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-dfz-network",
+      "lang": "in-ID",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-cab-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-cab-network",
+      "lang": "fr-CA",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hr-hr-x-hrb-network",
+      "name": "Android Speech Recognition and Synthesis from Google hr-hr-x-hrb-network",
+      "lang": "hr-HR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-jab-network",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-jab-network",
+      "lang": "ja-JP",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hr-hr-x-hra-network",
+      "name": "Android Speech Recognition and Synthesis from Google hr-hr-x-hra-network",
+      "lang": "hr-HR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google jv-id-x-jvf-network",
+      "name": "Android Speech Recognition and Synthesis from Google jv-id-x-jvf-network",
+      "lang": "jv-ID",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-idd-network",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-idd-network",
+      "lang": "in-ID",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-kob-network",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-kob-network",
+      "lang": "ko-KR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-zfg-network",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-zfg-network",
+      "lang": "pl-PL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-fic-network",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-fic-network",
+      "lang": "fil-PH",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eea-network",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eea-network",
+      "lang": "es-ES",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-cfc-network",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-cfc-network",
+      "lang": "fil-PH",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-tfb-network",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-tfb-network",
+      "lang": "nl-NL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-kda-network",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-kda-network",
+      "lang": "it-IT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ml-in-x-mlm-network",
+      "name": "Android Speech Recognition and Synthesis from Google ml-in-x-mlm-network",
+      "lang": "ml-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pac-network",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pac-network",
+      "lang": "pa-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-ena-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-ena-network",
+      "lang": "en-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-itc-network",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-itc-network",
+      "lang": "it-IT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iom-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iom-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eed-network",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eed-network",
+      "lang": "es-ES",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-mse-network",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-mse-network",
+      "lang": "ms-MY",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google th-th-x-mol-network",
+      "name": "Android Speech Recognition and Synthesis from Google th-th-x-mol-network",
+      "lang": "th-TH",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-cad-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-cad-network",
+      "lang": "fr-CA",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vic-network",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vic-network",
+      "lang": "vi-VN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-be-x-bed-network",
+      "name": "Android Speech Recognition and Synthesis from Google nl-be-x-bed-network",
+      "lang": "nl-BE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bnm-network",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bnm-network",
+      "lang": "bn-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-rue-network",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-rue-network",
+      "lang": "ru-RU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bnx-network",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bnx-network",
+      "lang": "bn-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iol-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iol-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-heb-network",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-heb-network",
+      "lang": "iw-IL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iob-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iob-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-jmn-network",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-jmn-network",
+      "lang": "pt-PT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google su-id-x-suf-network",
+      "name": "Android Speech Recognition and Synthesis from Google su-id-x-suf-network",
+      "lang": "su-ID",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-efu-network",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-efu-network",
+      "lang": "tr-TR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google mr-in-x-mrf-network",
+      "name": "Android Speech Recognition and Synthesis from Google mr-in-x-mrf-network",
+      "lang": "mr-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hie-network",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hie-network",
+      "lang": "hi-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ne-np-x-nep-network",
+      "name": "Android Speech Recognition and Synthesis from Google ne-np-x-nep-network",
+      "lang": "ne-NP",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-iog-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-iog-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-hec-network",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-hec-network",
+      "lang": "iw-IL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-fie-network",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-fie-network",
+      "lang": "fil-PH",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-dfc-network",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-dfc-network",
+      "lang": "ru-RU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-afb-network",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-afb-network",
+      "lang": "pl-PL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-nfh-network",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-nfh-network",
+      "lang": "de-DE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google km-kh-x-khm-network",
+      "name": "Android Speech Recognition and Synthesis from Google km-kh-x-khm-network",
+      "lang": "km-KH",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-frd-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-frd-network",
+      "lang": "fr-FR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-lfc-network",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-lfc-network",
+      "lang": "nl-NL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google te-in-x-tef-network",
+      "name": "Android Speech Recognition and Synthesis from Google te-in-x-tef-network",
+      "lang": "te-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-itb-network",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-itb-network",
+      "lang": "it-IT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-cmj-network",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-cmj-network",
+      "lang": "nb-NO",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-cfg-network",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-cfg-network",
+      "lang": "sv-SE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bs-ba-x-bsm-network",
+      "name": "Android Speech Recognition and Synthesis from Google bs-ba-x-bsm-network",
+      "lang": "bs-BA",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-dma-network",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-dma-network",
+      "lang": "nl-NL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google uk-ua-x-hfd-network",
+      "name": "Android Speech Recognition and Synthesis from Google uk-ua-x-hfd-network",
+      "lang": "uk-UA",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-cfl-network",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-cfl-network",
+      "lang": "nb-NO",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google gu-in-x-guf-network",
+      "name": "Android Speech Recognition and Synthesis from Google gu-in-x-guf-network",
+      "lang": "gu-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-dmc-network",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-dmc-network",
+      "lang": "sv-SE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-rfj-network",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-rfj-network",
+      "lang": "nb-NO",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-es-x-eec-network",
+      "name": "Android Speech Recognition and Synthesis from Google es-es-x-eec-network",
+      "lang": "es-ES",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-yfr-network",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-yfr-network",
+      "lang": "nl-NL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-tmg-network",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-tmg-network",
+      "lang": "nb-NO",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-tpc-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-tpc-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sr-rs-x-gfg-network",
+      "name": "Android Speech Recognition and Synthesis from Google sr-rs-x-gfg-network",
+      "lang": "sr-RS",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-jar-network",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-jar-network",
+      "lang": "yue-HK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google is-is-x-isf-network",
+      "name": "Android Speech Recognition and Synthesis from Google is-is-x-isf-network",
+      "lang": "is-IS",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google it-it-x-itd-network",
+      "name": "Android Speech Recognition and Synthesis from Google it-it-x-itd-network",
+      "lang": "it-IT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-arz-network",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-arz-network",
+      "lang": "ar",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ro-ro-x-vfv-network",
+      "name": "Android Speech Recognition and Synthesis from Google ro-ro-x-vfv-network",
+      "lang": "ro-RO",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google kn-in-x-knf-network",
+      "name": "Android Speech Recognition and Synthesis from Google kn-in-x-knf-network",
+      "lang": "kn-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-pmj-network",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-pmj-network",
+      "lang": "pt-PT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ml-in-x-mlf-network",
+      "name": "Android Speech Recognition and Synthesis from Google ml-in-x-mlf-network",
+      "lang": "ml-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-kfm-network",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-kfm-network",
+      "lang": "da-DK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-tpf-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-tpf-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-tpd-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-tpd-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cs-cz-x-jfs-network",
+      "name": "Android Speech Recognition and Synthesis from Google cs-cz-x-jfs-network",
+      "lang": "cs-CZ",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-mfm-network",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-mfm-network",
+      "lang": "tr-TR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-msg-network",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-msg-network",
+      "lang": "ms-MY",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google gu-in-x-gum-network",
+      "name": "Android Speech Recognition and Synthesis from Google gu-in-x-gum-network",
+      "lang": "gu-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nl-nl-x-bmh-network",
+      "name": "Android Speech Recognition and Synthesis from Google nl-nl-x-bmh-network",
+      "lang": "nl-NL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google nb-no-x-tfs-network",
+      "name": "Android Speech Recognition and Synthesis from Google nb-no-x-tfs-network",
+      "lang": "nb-NO",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-frc-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-frc-network",
+      "lang": "fr-FR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pl-pl-x-oda-network",
+      "name": "Android Speech Recognition and Synthesis from Google pl-pl-x-oda-network",
+      "lang": "pl-PL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbd-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbd-network",
+      "lang": "en-GB",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-rjs-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-rjs-network",
+      "lang": "en-GB",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google he-il-x-hee-network",
+      "name": "Android Speech Recognition and Synthesis from Google he-il-x-hee-network",
+      "lang": "iw-IL",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-msd-network",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-msd-network",
+      "lang": "ms-MY",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pad-network",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pad-network",
+      "lang": "pa-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sv-se-x-lfs-network",
+      "name": "Android Speech Recognition and Synthesis from Google sv-se-x-lfs-network",
+      "lang": "sv-SE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-ide-network",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-ide-network",
+      "lang": "in-ID",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccc-network",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ccc-network",
+      "lang": "zh-CN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bg-bg-x-ifk-network",
+      "name": "Android Speech Recognition and Synthesis from Google bg-bg-x-ifk-network",
+      "lang": "bg-BG",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ur-pk-x-cfn-network",
+      "name": "Android Speech Recognition and Synthesis from Google ur-pk-x-cfn-network",
+      "lang": "ur-PK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google sk-sk-x-sfk-network",
+      "name": "Android Speech Recognition and Synthesis from Google sk-sk-x-sfk-network",
+      "lang": "sk-SK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fil-ph-x-fid-network",
+      "name": "Android Speech Recognition and Synthesis from Google fil-ph-x-fid-network",
+      "lang": "fil-PH",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-vlf-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-vlf-network",
+      "lang": "fr-FR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-nmm-network",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-nmm-network",
+      "lang": "da-DK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pa-in-x-pae-network",
+      "name": "Android Speech Recognition and Synthesis from Google pa-in-x-pae-network",
+      "lang": "pa-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ms-my-x-msc-network",
+      "name": "Android Speech Recognition and Synthesis from Google ms-my-x-msc-network",
+      "lang": "ms-MY",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ssa-network",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-ssa-network",
+      "lang": "zh-CN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-jfb-network",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-jfb-network",
+      "lang": "pt-PT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-arc-network",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-arc-network",
+      "lang": "ar",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-cac-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-cac-network",
+      "lang": "fr-CA",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-br-x-pte-network",
+      "name": "Android Speech Recognition and Synthesis from Google pt-br-x-pte-network",
+      "lang": "pt-BR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-deg-network",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-deg-network",
+      "lang": "de-DE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google et-ee-x-tms-network",
+      "name": "Android Speech Recognition and Synthesis from Google et-ee-x-tms-network",
+      "lang": "et-EE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ta-in-x-tac-network",
+      "name": "Android Speech Recognition and Synthesis from Google ta-in-x-tac-network",
+      "lang": "ta-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruf-network",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-ruf-network",
+      "lang": "ru-RU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google de-de-x-dea-network",
+      "name": "Android Speech Recognition and Synthesis from Google de-de-x-dea-network",
+      "lang": "de-DE",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google id-id-x-idc-network",
+      "name": "Android Speech Recognition and Synthesis from Google id-id-x-idc-network",
+      "lang": "in-ID",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-tmc-network",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-tmc-network",
+      "lang": "tr-TR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google da-dk-x-vfb-network",
+      "name": "Android Speech Recognition and Synthesis from Google da-dk-x-vfb-network",
+      "lang": "da-DK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-ism-network",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-ism-network",
+      "lang": "ko-KR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google hi-in-x-hid-network",
+      "name": "Android Speech Recognition and Synthesis from Google hi-in-x-hid-network",
+      "lang": "hi-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-us-x-sfg-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-us-x-sfg-network",
+      "lang": "en-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bnf-network",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bnf-network",
+      "lang": "bn-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-br-x-ptd-network",
+      "name": "Android Speech Recognition and Synthesis from Google pt-br-x-ptd-network",
+      "lang": "pt-BR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-aud-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-aud-network",
+      "lang": "en-AU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ko-kr-x-koc-network",
+      "name": "Android Speech Recognition and Synthesis from Google ko-kr-x-koc-network",
+      "lang": "ko-KR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-fra-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-fra-network",
+      "lang": "fr-FR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-esc-network",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-esc-network",
+      "lang": "es-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-fr-x-frb-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-fr-x-frb-network",
+      "lang": "fr-FR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ca-es-x-caf-network",
+      "name": "Android Speech Recognition and Synthesis from Google ca-es-x-caf-network",
+      "lang": "ca-ES",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbg-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbg-network",
+      "lang": "en-GB",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-cn-x-cce-network",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-cn-x-cce-network",
+      "lang": "zh-CN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yud-network",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yud-network",
+      "lang": "yue-HK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vid-network",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vid-network",
+      "lang": "vi-VN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ar-xa-x-are-network",
+      "name": "Android Speech Recognition and Synthesis from Google ar-xa-x-are-network",
+      "lang": "ar",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-pt-x-sfs-network",
+      "name": "Android Speech Recognition and Synthesis from Google pt-pt-x-sfs-network",
+      "lang": "pt-PT",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google te-in-x-tem-network",
+      "name": "Android Speech Recognition and Synthesis from Google te-in-x-tem-network",
+      "lang": "te-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google el-gr-x-vfz-network",
+      "name": "Android Speech Recognition and Synthesis from Google el-gr-x-vfz-network",
+      "lang": "el-GR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google bn-in-x-bin-network",
+      "name": "Android Speech Recognition and Synthesis from Google bn-in-x-bin-network",
+      "lang": "bn-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fr-ca-x-caa-network",
+      "name": "Android Speech Recognition and Synthesis from Google fr-ca-x-caa-network",
+      "lang": "fr-CA",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ja-jp-x-jac-network",
+      "name": "Android Speech Recognition and Synthesis from Google ja-jp-x-jac-network",
+      "lang": "ja-JP",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google fi-fi-x-afi-network",
+      "name": "Android Speech Recognition and Synthesis from Google fi-fi-x-afi-network",
+      "lang": "fi-FI",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-esd-network",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-esd-network",
+      "lang": "es-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ru-ru-x-rud-network",
+      "name": "Android Speech Recognition and Synthesis from Google ru-ru-x-rud-network",
+      "lang": "ru-RU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google pt-br-x-afs-network",
+      "name": "Android Speech Recognition and Synthesis from Google pt-br-x-afs-network",
+      "lang": "pt-BR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-au-x-aub-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-au-x-aub-network",
+      "lang": "en-AU",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ur-pk-x-urm-network",
+      "name": "Android Speech Recognition and Synthesis from Google ur-pk-x-urm-network",
+      "lang": "ur-PK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google tr-tr-x-ama-network",
+      "name": "Android Speech Recognition and Synthesis from Google tr-tr-x-ama-network",
+      "lang": "tr-TR",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google es-us-x-sfb-network",
+      "name": "Android Speech Recognition and Synthesis from Google es-us-x-sfb-network",
+      "lang": "es-US",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cy-gb-x-cyf-network",
+      "name": "Android Speech Recognition and Synthesis from Google cy-gb-x-cyf-network",
+      "lang": "cy-GB",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-in-x-end-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-in-x-end-network",
+      "lang": "en-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuf-network",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yuf-network",
+      "lang": "yue-HK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctc-network",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-tw-x-ctc-network",
+      "lang": "zh-TW",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google cmn-tw-x-cte-network",
+      "name": "Android Speech Recognition and Synthesis from Google cmn-tw-x-cte-network",
+      "lang": "zh-TW",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-vif-network",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-vif-network",
+      "lang": "vi-VN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google en-gb-x-gbb-network",
+      "name": "Android Speech Recognition and Synthesis from Google en-gb-x-gbb-network",
+      "lang": "en-GB",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google ta-in-x-tad-network",
+      "name": "Android Speech Recognition and Synthesis from Google ta-in-x-tad-network",
+      "lang": "ta-IN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google yue-hk-x-yue-network",
+      "name": "Android Speech Recognition and Synthesis from Google yue-hk-x-yue-network",
+      "lang": "yue-HK",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google lv-lv-x-imr-network",
+      "name": "Android Speech Recognition and Synthesis from Google lv-lv-x-imr-network",
+      "lang": "lv-LV",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "Android Speech Recognition and Synthesis from Google vi-vn-x-gft-network",
+      "name": "Android Speech Recognition and Synthesis from Google vi-vn-x-gft-network",
+      "lang": "vi-VN",
+      "localService": false,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Arabic",
+      "name": "eSpeak Arabic",
+      "lang": "ar",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Bulgarian",
+      "name": "eSpeak Bulgarian",
+      "lang": "bg",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Bengali",
+      "name": "eSpeak Bengali",
+      "lang": "bn",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Catalan",
+      "name": "eSpeak Catalan",
+      "lang": "ca",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Chinese (Mandarin, latin as English)",
+      "name": "eSpeak Chinese (Mandarin, latin as English)",
+      "lang": "cmn",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Czech",
+      "name": "eSpeak Czech",
+      "lang": "cs",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Danish",
+      "name": "eSpeak Danish",
+      "lang": "da",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak German",
+      "name": "eSpeak German",
+      "lang": "de",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Greek",
+      "name": "eSpeak Greek",
+      "lang": "el",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Spanish (Spain)",
+      "name": "eSpeak Spanish (Spain)",
+      "lang": "es",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Estonian",
+      "name": "eSpeak Estonian",
+      "lang": "et",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Persian",
+      "name": "eSpeak Persian",
+      "lang": "fa",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Finnish",
+      "name": "eSpeak Finnish",
+      "lang": "fi",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Gujarati",
+      "name": "eSpeak Gujarati",
+      "lang": "gu",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Croatian",
+      "name": "eSpeak Croatian",
+      "lang": "hr",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Hungarian",
+      "name": "eSpeak Hungarian",
+      "lang": "hu",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Indonesian",
+      "name": "eSpeak Indonesian",
+      "lang": "id",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Italian",
+      "name": "eSpeak Italian",
+      "lang": "it",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Kannada",
+      "name": "eSpeak Kannada",
+      "lang": "kn",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Korean",
+      "name": "eSpeak Korean",
+      "lang": "ko",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Lithuanian",
+      "name": "eSpeak Lithuanian",
+      "lang": "lt",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Latvian",
+      "name": "eSpeak Latvian",
+      "lang": "lv",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Malayalam",
+      "name": "eSpeak Malayalam",
+      "lang": "ml",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Marathi",
+      "name": "eSpeak Marathi",
+      "lang": "mr",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Malay",
+      "name": "eSpeak Malay",
+      "lang": "ms",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Norwegian Bokmål",
+      "name": "eSpeak Norwegian Bokmål",
+      "lang": "nb",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Polish",
+      "name": "eSpeak Polish",
+      "lang": "pl",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Portuguese (Brazil)",
+      "name": "eSpeak Portuguese (Brazil)",
+      "lang": "pt-br",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Romanian",
+      "name": "eSpeak Romanian",
+      "lang": "ro",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Russian",
+      "name": "eSpeak Russian",
+      "lang": "ru",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Slovak",
+      "name": "eSpeak Slovak",
+      "lang": "sk",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Slovenian",
+      "name": "eSpeak Slovenian",
+      "lang": "sl",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Serbian",
+      "name": "eSpeak Serbian",
+      "lang": "sr",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Swedish",
+      "name": "eSpeak Swedish",
+      "lang": "sv",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Swahili",
+      "name": "eSpeak Swahili",
+      "lang": "sw",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Tamil",
+      "name": "eSpeak Tamil",
+      "lang": "ta",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Telugu",
+      "name": "eSpeak Telugu",
+      "lang": "te",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Turkish",
+      "name": "eSpeak Turkish",
+      "lang": "tr",
+      "localService": true,
+      "default": false
+    },
+    {
+      "voiceURI": "eSpeak Vietnamese (Northern)",
+      "name": "eSpeak Vietnamese (Northern)",
+      "lang": "vi",
+      "localService": true,
+      "default": false
+    }
+  ]
+}

--- a/demo/article/script.js
+++ b/demo/article/script.js
@@ -188,7 +188,9 @@ function populateVoiceSelect() {
 
   try {
     // Sort by region while preserving quality order within each region
-    const sortedVoices = voiceManager.sortVoicesByRegions(window.navigator.languages, enVoices);
+    const sortedVoices = voiceManager.sortVoicesByRegions(["en"], enVoices);
+
+    console.log(sortedVoices);
 
     let currentRegion = null;
     let optgroup = null;

--- a/demo/article/script.js
+++ b/demo/article/script.js
@@ -14,7 +14,7 @@ const readAlongCheckbox = document.getElementById("readAlong");
 // State
 let voiceManager;
 let navigator;
-let allVoices = [];
+let enVoices = [];
 let currentVoice = null;
 let isPlaying = false;
 let utterances = [];
@@ -28,7 +28,7 @@ async function initialize() {
     voiceManager = await WebSpeechVoiceManager.initialize();
     
     // Only get English voices
-    allVoices = voiceManager.getVoices({languages: "en"});
+    enVoices = voiceManager.getVoices({languages: "en", removeDuplicates: true});
     
     // Initialize the navigator
     navigator = new WebSpeechReadAloudNavigator();
@@ -43,7 +43,7 @@ async function initialize() {
     populateVoiceSelect();
     
     // Get the default voice for English
-    currentVoice = voiceManager.getDefaultVoice("en-US");
+    currentVoice = voiceManager.getDefaultVoice("en");
 
     if (currentVoice && navigator) {
       navigator.setVoice(currentVoice);
@@ -178,7 +178,7 @@ function populateVoiceSelect() {
   
   voiceSelect.innerHTML = "<option value=\"\" disabled selected>Select a voice</option>";
   
-  if (!allVoices || !allVoices.length) {
+  if (!enVoices || !enVoices.length) {
     const option = document.createElement("option");
     option.disabled = true;
     option.textContent = "No voices available. Please check your browser settings and internet connection.";
@@ -188,7 +188,7 @@ function populateVoiceSelect() {
 
   try {
     // Sort by region while preserving quality order within each region
-    const sortedVoices = voiceManager.sortVoicesByRegions(allVoices, window.navigator.languages);
+    const sortedVoices = voiceManager.sortVoicesByRegions(window.navigator.languages, enVoices);
 
     let currentRegion = null;
     let optgroup = null;
@@ -232,7 +232,7 @@ function populateVoiceSelect() {
   } catch (error) {
     console.error("Error populating voice dropdown:", error);
     // Fallback to simple list if there's an error
-    allVoices.forEach(voice => {
+    enVoices.forEach(voice => {
       const option = document.createElement("option");
       option.value = voice.name;
       option.textContent = [
@@ -315,7 +315,7 @@ async function handleVoiceChange(e) {
   if (!voiceName) return;
   
   // Find the selected voice by name
-  currentVoice = allVoices.find(v => v.name === voiceName);
+  currentVoice = enVoices.find(v => v.name === voiceName);
   
   if (!currentVoice) {
     console.error("Voice not found:", voiceName);

--- a/demo/script.js
+++ b/demo/script.js
@@ -65,15 +65,15 @@ speechNavigator.on("error", (event) => {
 
 // Initialize the application
 async function init() {
-  try {    
+  try {
     // Initialize the voice manager
     voiceManager = await WebSpeechVoiceManager.initialize();
     
     // Sort those voices by browser preference using sortVoicesByRegions
     const voices = voiceManager.sortVoicesByRegions(window.navigator.languages);
     
-    // Get languages, excluding novelty and very low quality voices
-    languages = voiceManager.getLanguages(window.navigator.language, undefined, voices);
+    // Get languages
+    languages = voiceManager.getLanguages(window.navigator.languages[0], { removeDuplicates: true }, voices);
     
     // Populate language dropdown
     populateLanguageDropdown();
@@ -241,7 +241,7 @@ function filterVoices() {
   const source = sourceSelect.value;
   const offlineOnly = offlineOnlyCheckbox.checked;
 
-  const filterOptions = {};
+  const filterOptions = { };
   
   if (gender !== "all") {
     filterOptions.gender = gender;
@@ -264,7 +264,7 @@ function filterVoices() {
   // Now apply language filter if needed
   if (language) {
     filterOptions.languages = language;
-    filteredVoices = voiceManager.filterVoices(voicesFilteredExceptLanguage, { languages: language });
+    filteredVoices = voiceManager.filterVoices({ languages: language }, voicesFilteredExceptLanguage);
   } else {
     filteredVoices = voicesFilteredExceptLanguage;
   }

--- a/demo/script.js
+++ b/demo/script.js
@@ -29,7 +29,6 @@ let jumpInputUserChanged = false;
 
 // State
 let voiceManager;
-let allVoices = [];
 let filteredVoices = [];
 let languages = [];
 let currentVoice = null;
@@ -69,33 +68,12 @@ async function init() {
   try {    
     // Initialize the voice manager
     voiceManager = await WebSpeechVoiceManager.initialize();
-
-    const initOptions = {
-      excludeNovelty: true,
-      excludeVeryLowQuality: true
-    };
     
-    // Load all available voices
-    allVoices = voiceManager.getVoices(initOptions);
+    // Sort those voices by browser preference using sortVoicesByRegions
+    const voices = voiceManager.sortVoicesByRegions(window.navigator.languages);
     
     // Get languages, excluding novelty and very low quality voices
-    const allLanguages = voiceManager.getLanguages(window.navigator.language, initOptions);
-    
-    // Sort languages with browser's preferred languages first
-    languages = allLanguages
-      .map(lang => ({
-        ...lang,
-        language: lang.code,
-        name: lang.label
-      }));
-    
-    // Sort using the manager's sortRegions method
-    languages = voiceManager.sortVoicesByRegions(languages, window.navigator.languages)
-      .map(voice => ({
-        code: voice.language,
-        label: voice.name,
-        count: voice.count
-      }));
+    languages = voiceManager.getLanguages(window.navigator.language, undefined, voices);
     
     // Populate language dropdown
     populateLanguageDropdown();
@@ -278,7 +256,7 @@ function filterVoices() {
   }
   
   // Filter voices once with all filters except language
-  let voicesFilteredExceptLanguage = voiceManager.filterVoices(allVoices, filterOptions);
+  let voicesFilteredExceptLanguage = voiceManager.filterVoices(filterOptions);
   
   // Update language counts using the filtered voices
   updateLanguageCounts(voicesFilteredExceptLanguage);
@@ -313,10 +291,10 @@ function populateVoiceDropdown() {
     }
 
     // Sort voices with browser's preferred languages first
-    const sortedVoices = voiceManager.sortVoicesByRegions([...filteredVoices], window.navigator.languages);
+    const sortedVoices = voiceManager.sortVoicesByRegions(window.navigator.languages, [...filteredVoices]);
 
     // Group the sorted voices by region
-    const voiceGroups = voiceManager.groupVoices(sortedVoices, "region");
+    const voiceGroups = voiceManager.groupVoices("region", sortedVoices);
 
     // Add optgroups for each region
     for (const [region, voices] of Object.entries(voiceGroups)) {

--- a/json/en.json
+++ b/json/en.json
@@ -1973,7 +1973,7 @@
         "en-au-x-aub-local"
       ],
       "language": "en-AU",
-      "gender": "female",
+      "gender": "male",
       "quality": [
         "high"
       ],
@@ -1998,7 +1998,7 @@
         "en-au-x-aud-local"
       ],
       "language": "en-AU",
-      "gender": "female",
+      "gender": "male",
       "quality": [
         "high"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/speech",
-  "version": "0.1.0-beta.5",
+  "version": "0.1.0-beta.6",
   "description": "Readium Speech is a TypeScript library for implementing a read aloud feature with Web technologies. It follows [best practices](https://github.com/HadrienGardeur/read-aloud-best-practices) gathered through interviews with members of the digital publishing industry.",
   "main": "./build/index.cjs",
   "module": "./build/index.js",

--- a/src/WebSpeech/WebSpeechVoiceManager.ts
+++ b/src/WebSpeech/WebSpeechVoiceManager.ts
@@ -705,11 +705,8 @@ private static sortByQuality(
       const bOrder = langOrderMap.get(b.name);
       
       if (aOrder !== undefined && bOrder !== undefined) {
-        // Both have JSON order - use it if same quality or both no quality
-        if ((aQuality > 0 && bQuality > 0 && aQuality === bQuality) || 
-            (aQuality === 0 && bQuality === 0)) {
-          return aOrder - bOrder;
-        }
+        // Both have JSON order - always use it for JSON voices
+        return aOrder - bOrder;
       }
     }
   }
@@ -909,8 +906,7 @@ private static sortByQuality(
       if (aIsDefault && !bIsDefault) return -1;
       if (!aIsDefault && bIsDefault) return 1;
       
-      // Sort alphabetically by region
-      return (aRegion || "").localeCompare(bRegion || "");
+      return WebSpeechVoiceManager.sortByQuality(a, b, jsonOrderMaps, processedLang.baseLang);
     });
   }
 

--- a/src/WebSpeech/WebSpeechVoiceManager.ts
+++ b/src/WebSpeech/WebSpeechVoiceManager.ts
@@ -373,21 +373,23 @@ export class WebSpeechVoiceManager {
   /**
    * Get available regions with voice counts
    * @param localization Optional BCP 47 language tag to use for region names
+   * @param filterOptions Optional filters to apply to voices before counting regions
    * @param voices Optional array of voices to count (defaults to this.voices)
    */
-  getRegions(localization?: string, voices?: ReadiumSpeechVoice[]): LanguageInfo[] {
+  getRegions(localization?: string, filterOptions?: VoiceFilterOptions, voices?: ReadiumSpeechVoice[]): LanguageInfo[] {
     if (!voices && !this.isInitialized) {
       throw new Error("WebSpeechVoiceManager not initialized. Call initialize() first.");
     }
     
     const voicesToCount = voices ?? this.voices;
+    const filteredVoices = filterOptions ? this.filterVoices(filterOptions, voicesToCount) : voicesToCount;
     
     const result: { code: string; label: string; count: number }[] = [];
     const seen = new Set<string>();
     const counts = new Map<string, number>();
     
     // Count regions first
-    for (const voice of voicesToCount) {
+    for (const voice of filteredVoices) {
       const [, region] = WebSpeechVoiceManager.extractLangRegionFromBCP47(voice.language);
       if (region) {
         counts.set(region, (counts.get(region) || 0) + 1);
@@ -395,7 +397,7 @@ export class WebSpeechVoiceManager {
     }
     
     // Preserve order
-    for (const voice of voicesToCount) {
+    for (const voice of filteredVoices) {
       const [, region] = WebSpeechVoiceManager.extractLangRegionFromBCP47(voice.language);
       if (region && !seen.has(region)) {
         let displayName = voice.language;

--- a/test/WebSpeechVoiceManager/filterVoices.test.ts
+++ b/test/WebSpeechVoiceManager/filterVoices.test.ts
@@ -1,4 +1,4 @@
-import { type ExecutionContext } from "ava";
+import test, { type ExecutionContext } from "ava";
 import { testWithContext, TestContext, createTestVoice } from "./setup.js";
 import { ReadiumSpeechVoice, WebSpeechVoiceManager } from "../../build/index.js";
 
@@ -36,11 +36,11 @@ testWithContext("filterVoices: filters by language", (t: ExecutionContext<TestCo
     createTestVoice({ name: "Spanish Voice", language: "es-ES" })
   ];
   
-  const englishVoices = manager.filterVoices(testVoices, { languages: "en" });
+  const englishVoices = manager.filterVoices({ languages: "en" }, testVoices);
   t.is(englishVoices.length, 2);
   t.true(englishVoices.every(v => v.language.startsWith("en")));
   
-  const multiLangVoices = manager.filterVoices(testVoices, { languages: ["en", "fr"] });
+  const multiLangVoices = manager.filterVoices({ languages: ["en", "fr"] }, testVoices);
   t.is(multiLangVoices.length, 3);
   t.true(multiLangVoices.every(v => v.language.startsWith("en") || v.language.startsWith("fr")));
 });
@@ -55,11 +55,11 @@ testWithContext("filterVoices: filters by source", (t: ExecutionContext<TestCont
     createTestVoice({ name: "Browser Voice 1", source: "browser" }),
   ];
   
-  const jsonVoices = manager.filterVoices(testVoices, { source: "json" });
+  const jsonVoices = manager.filterVoices({ source: "json" }, testVoices);
   t.is(jsonVoices.length, 2);
   t.true(jsonVoices.every(v => v.source === "json"));
 
-  const browserVoices = manager.filterVoices(testVoices, { source: "browser"});
+  const browserVoices = manager.filterVoices({ source: "browser" }, testVoices);
   t.is(browserVoices.length, 1);
   t.true(browserVoices.every(v => v.source === "browser"));
 });
@@ -75,11 +75,11 @@ testWithContext("filterVoices: filters by gender", (t: ExecutionContext<TestCont
     createTestVoice({ name: "Unknown Gender Voice", language: "en-US" })
   ];
   
-  const maleVoices = manager.filterVoices(testVoices, { gender: "male" });
+  const maleVoices = manager.filterVoices({ gender: "male" }, testVoices);
   t.is(maleVoices.length, 2);
   t.true(maleVoices.every(v => v.gender === "male"));
   
-  const femaleVoices = manager.filterVoices(testVoices, { gender: "female" });
+  const femaleVoices = manager.filterVoices({ gender: "female" }, testVoices);
   t.is(femaleVoices.length, 1);
   t.is(femaleVoices[0].gender, "female");
 });
@@ -97,15 +97,15 @@ testWithContext("filterVoices: filters by quality array", (t: ExecutionContext<T
   ];
   
   // Test single quality filter
-  const highQualityVoices = manager.filterVoices(testVoices, { quality: "high" });
+  const highQualityVoices = manager.filterVoices({ quality: "high" }, testVoices);
   t.is(highQualityVoices.length, 1); // Only the high quality voice
   
   // Test multiple quality filter
-  const multiQualityVoices = manager.filterVoices(testVoices, { quality: ["high", "normal"] });
+  const multiQualityVoices = manager.filterVoices({ quality: ["high", "normal"] }, testVoices);
   t.is(multiQualityVoices.length, 2); // high and normal quality voices
   
   // Test that undefined quality voices are filtered out
-  const filteredVoices = manager.filterVoices(testVoices, { quality: "high" });
+  const filteredVoices = manager.filterVoices({ quality: "high" }, testVoices);
   t.false(filteredVoices.some(v => v.quality === undefined));
 });
 
@@ -129,17 +129,17 @@ testWithContext("filterVoices: filters out novelty and low quality voices", (t: 
   ];
 
   // Test filtering with default options (should filter out both voices)
-  const filteredVoices = manager.filterVoices(testVoices, {
+  const filteredVoices = manager.filterVoices({
     excludeNovelty: true,
     excludeVeryLowQuality: true
-  });
+  }, testVoices);
   t.is(filteredVoices.length, 0, "Should filter out all test voices by default");
   
   // Test including them by disabling the filters
-  const allVoices = manager.filterVoices(testVoices, { 
+  const allVoices = manager.filterVoices({ 
     excludeNovelty: false, 
     excludeVeryLowQuality: false 
-  });
+  }, testVoices);
   t.is(allVoices.length, 2, "Should include all voices when not filtered");
 });
 
@@ -154,7 +154,7 @@ testWithContext("filterVoices: filters by offline availability", (t: ExecutionCo
     createTestVoice({ name: "Undefined Availability Voice", language: "en-US" })
   ];
   
-  const offlineVoices = manager.filterVoices(testVoices, { offlineOnly: true });
+  const offlineVoices = manager.filterVoices({ offlineOnly: true }, testVoices);
   t.is(offlineVoices.length, 2);
   t.true(offlineVoices.every(v => v.offlineAvailability === true));
   
@@ -174,12 +174,12 @@ testWithContext("filterVoices: filters by provider", (t: ExecutionContext<TestCo
     createTestVoice({ name: "Another Google Voice", language: "en-US", provider: "Google" })
   ];
   
-  const googleVoices = manager.filterVoices(testVoices, { provider: "Google" });
+  const googleVoices = manager.filterVoices({ provider: "Google" }, testVoices);
   t.is(googleVoices.length, 2);
   t.true(googleVoices.every(v => v.provider === "Google"));
   
   // Test case insensitive matching
-  const caseInsensitiveVoices = manager.filterVoices(testVoices, { provider: "google" });
+  const caseInsensitiveVoices = manager.filterVoices({ provider: "google" }, testVoices);
   t.is(caseInsensitiveVoices.length, 2);
 });
 
@@ -195,20 +195,20 @@ testWithContext("filterVoices: combines multiple filters", (t: ExecutionContext<
   ];
   
   // Filter by language and gender
-  const englishFemaleVoices = manager.filterVoices(testVoices, { 
+  const englishFemaleVoices = manager.filterVoices({ 
     languages: "en", 
     gender: "female" 
-  });
+  }, testVoices);
   t.is(englishFemaleVoices.length, 2);
   t.true(englishFemaleVoices.every(v => 
     v.language.startsWith("en") && v.gender === "female"
   ));
   
   // Filter by quality and provider
-  const highQualityGoogleVoices = manager.filterVoices(testVoices, { 
+  const highQualityGoogleVoices = manager.filterVoices({ 
     quality: "high", 
     provider: "Google" 
-  });
+  }, testVoices);
   t.is(highQualityGoogleVoices.length, 1);
   t.is(highQualityGoogleVoices[0].name, "Male High Quality English");
 });
@@ -223,18 +223,18 @@ testWithContext("filterVoices: handles edge cases", (t: ExecutionContext<TestCon
   ];
   
   // Test empty filter arrays
-  const emptyLanguageFilter = manager.filterVoices(testVoices, { languages: [] });
+  const emptyLanguageFilter = manager.filterVoices({ languages: [] }, testVoices);
   t.is(emptyLanguageFilter.length, 0);
   
-  const emptyQualityFilter = manager.filterVoices(testVoices, { quality: undefined });
+  const emptyQualityFilter = manager.filterVoices({ quality: undefined }, testVoices);
   t.is(emptyQualityFilter.length, testVoices.length, "Should return all voices when quality is undefined");
   
   // Test case sensitivity for language
-  const caseSensitiveLanguage = manager.filterVoices(testVoices, { languages: "EN-us" });
+  const caseSensitiveLanguage = manager.filterVoices({ languages: "EN-us" }, testVoices);
   t.is(caseSensitiveLanguage.length, 1); // Should match due to toLowerCase()
   
   // Test invalid quality values - cast to any for testing invalid input
-  const invalidQualityFilter = manager.filterVoices(testVoices, { quality: "invalid" as any });
+  const invalidQualityFilter = manager.filterVoices({ quality: "invalid" as any }, testVoices);
   t.is(invalidQualityFilter.length, 0);
 });
 
@@ -250,10 +250,10 @@ testWithContext("filterVoices: uses array values for multiple filters", (t: Exec
   ];
   
   // Test with array of languages and array of qualities
-  const filtered = manager.filterVoices(testVoices, { 
+  const filtered = manager.filterVoices({ 
     languages: ["en", "fr"], 
     quality: ["high", "normal"] 
-  });
+  }, testVoices);
   t.is(filtered.length, 3);
   t.true(filtered.every(v => 
     (v.language.startsWith("en") || v.language.startsWith("fr")) &&
@@ -289,4 +289,163 @@ testWithContext("filterOutVeryLowQualityVoices: removes very low quality voices"
   const filtered = manager.filterOutVeryLowQualityVoices(testVoices);
   t.is(filtered.length, testVoices.length - 1);
   t.false(filtered.some((v: ReadiumSpeechVoice) => v.quality === "veryLow"));
+});
+
+testWithContext("filterVoices: deduplication keeps higher quality voice from voiceURI package name", (t) => {
+  const manager = t.context.manager;
+  
+  // Define test voices once
+  const lowVoice = {
+    voiceURI: "com.apple.speech.synthesis.voice.compact.samantha",
+    name: "Samantha",
+    lang: "en-US",
+    localService: true,
+    default: false
+  };
+
+  const normalVoice = {
+    voiceURI: "com.apple.speech.synthesis.voice.enhanced.samantha",
+    name: "Samantha (enhanced)",
+    lang: "en-US",
+    localService: true,
+    default: false
+  };
+
+  // Parse both voices and apply deduplication through filtering
+  const parsedVoices = (manager as any).parseToReadiumSpeechVoices([lowVoice, normalVoice]);
+  const deduped = manager.filterVoices({ removeDuplicates: true }, parsedVoices);
+  
+  // Verify the result
+  t.is(deduped.length, 1, "Should only keep one voice after deduplication");
+  const resultVoice = deduped[0];
+  t.is(resultVoice.name, "Samantha", "Should use the JSON name of the voice");
+  t.is(resultVoice.originalName, "Samantha (enhanced)", "Should keep the original name of the higher quality voice");
+  t.deepEqual(resultVoice.quality, "normal", "Should keep the voice with normal quality");
+});
+
+testWithContext("filterVoices: deduplication keeps higher quality voice from voiceURI string", (t) => {
+  const manager = t.context.manager;
+  
+  // Define test voices once
+  const basicVoice = {
+    voiceURI: "Samantha",
+    name: "Samantha",
+    lang: "en-US",
+    localService: true,
+    default: false
+  };
+
+  const enhancedVoice = {
+    voiceURI: "Samantha (Premium)",
+    name: "Samantha (Premium)",
+    lang: "en-US",
+    localService: true,
+    default: false
+  };
+
+  // Parse both voices and apply deduplication through filtering
+  const parsedVoices = (manager as any).parseToReadiumSpeechVoices([basicVoice, enhancedVoice]);
+  const deduped = manager.filterVoices({ removeDuplicates: true }, parsedVoices);
+  
+  // Verify the result
+  t.is(deduped.length, 1, "Should only keep one voice after deduplication");
+  const resultVoice = deduped[0];
+  t.is(resultVoice.name, "Samantha", "Should use the JSON name of the voice");
+  t.is(resultVoice.originalName, "Samantha (Premium)", "Should keep the original name of the higher quality voice");
+  t.deepEqual(resultVoice.quality, "high", "Should keep the voice with high quality");
+});
+
+testWithContext("filterVoices: deduplication keeps higher quality voice from json quality array", (t) => {
+  const manager = t.context.manager;
+  
+  // Parse both voices together to get correct duplicate counts
+  const voices = (manager as any).parseToReadiumSpeechVoices([
+    {
+      voiceURI: "Samantha",
+      name: "Samantha",
+      lang: "en-US",
+      localService: true,
+      default: false
+    },
+    {
+      voiceURI: "Samantha superior",
+      name: "Samantha (Superior)",
+      lang: "en-US",
+      localService: true,
+      default: false
+    }
+  ]);
+  // Now test deduplication with both voices
+  const deduped = manager.filterVoices({ removeDuplicates: true }, voices);
+  
+  // Verify only the higher quality voice remains with its original name
+  t.is(deduped.length, 1, "Should only keep one voice after deduplication");
+  t.is(deduped[0].name, "Samantha", "Should use the JSON name of the voice");
+  t.is(deduped[0].originalName, "Samantha (Superior)", "Should keep the original name of the higher quality voice");
+  t.is(deduped[0].voiceURI, "Samantha superior", "Should keep the voice with superior quality");
+  t.deepEqual(deduped[0].quality, "normal", "Should find the voice with normal quality from the array");
+});
+
+testWithContext("filterVoices: deduplication prefers voice with matching name over altNames", (t) => {
+  const manager = t.context.manager;
+  
+  // Test scenario: two browser voices
+  // One matches primary name in JSON, other matches altName in JSON
+  const voices = [
+    {
+      voiceURI: "Google US English 5 (Natural)",
+      name: "Google US English 5 (Natural)",
+      lang: "en-US",
+      localService: true,
+      default: false
+    },
+    {
+      voiceURI: "Android Speech Recognition and Synthesis from Google en-us-x-tpc-local",
+      name: "Android Speech Recognition and Synthesis from Google en-us-x-tpc-local",
+      lang: "en-US",
+      localService: true,
+      default: false
+    }
+  ];
+  
+  const parsedVoices = (manager as any).parseToReadiumSpeechVoices(voices);
+  const deduped = manager.filterVoices({ removeDuplicates: true }, parsedVoices);
+  
+  // Should only keep one voice
+  t.is(deduped.length, 1, "Should only keep one voice after deduplication");
+  // Should prefer the voice with the primary name (Google US English 5 (Natural))
+  t.is(deduped[0].name, "Google US English 5 (Natural)", "Should prefer voice with primary name over altName");
+  t.is(deduped[0].originalName, "Google US English 5 (Natural)", "Should keep the original name of preferred voice");
+});
+
+testWithContext("filterVoices: deduplication prefers voice with earlier altName over later altName", (t) => {
+  const manager = t.context.manager;
+  
+  // Test scenario: two browser voices 
+  // Both match different altNames in same JSON voice entry
+  const voices = [
+    {
+      voiceURI: "Android Speech Recognition and Synthesis from Google en-us-x-tpc-local",
+      name: "Android Speech Recognition and Synthesis from Google en-us-x-tpc-local",
+      lang: "en-US",
+      localService: true,
+      default: false
+    },
+    {
+      voiceURI: "Android Speech Recognition and Synthesis from Google en-us-x-tpc-network", 
+      name: "Android Speech Recognition and Synthesis from Google en-us-x-tpc-network",
+      lang: "en-US",
+      localService: true,
+      default: false
+    }
+  ];
+  
+  const parsedVoices = (manager as any).parseToReadiumSpeechVoices(voices);
+  const deduped = manager.filterVoices({ removeDuplicates: true }, parsedVoices);
+  
+  // Should only keep one voice
+  t.is(deduped.length, 1, "Should only keep one voice after deduplication");
+  // Should prefer the voice with the earlier altName (network comes before local in JSON)
+  t.is(deduped[0].name, "Google US English 5 (Natural)", "Should prefer voice with earlier altName");
+  t.is(deduped[0].originalName, "Android Speech Recognition and Synthesis from Google en-us-x-tpc-network", "Should prefer voice with earlier altName");
 });

--- a/test/WebSpeechVoiceManager/getLanguages.test.ts
+++ b/test/WebSpeechVoiceManager/getLanguages.test.ts
@@ -1,5 +1,5 @@
 import { type ExecutionContext } from "ava";
-import { testWithContext, TestContext, mockVoices, mockSpeechSynthesis } from "./setup.js";
+import { testWithContext, TestContext, mockSpeechSynthesis, createTestVoice } from "./setup.js";
 import { WebSpeechVoiceManager } from "../../build/index.js";
 
 // =============================================
@@ -65,84 +65,60 @@ testWithContext("getLanguages: handles empty voices array", async (t: ExecutionC
   }
 });
 
-// =============================================
-// 4. Region Retrieval Tests
-// =============================================
-
-testWithContext("getRegions: returns available regions with counts", async (t: ExecutionContext<TestContext>) => {
-  const regions = await t.context.manager.getRegions();
-  t.true(Array.isArray(regions));
+testWithContext("getLanguages: works with provided voices array", async (t: ExecutionContext<TestContext>) => {
+  const manager = t.context.manager;
   
-  // Check that we have at least one region
-  t.true(regions.length > 0);
+  // Create custom voices using the helper
+  const customVoices = [
+    createTestVoice({
+      name: "Custom Voice 1",
+      language: "en-US",
+      voiceURI: "custom-voice-1"
+    }),
+    createTestVoice({
+      name: "Custom Voice 2", 
+      language: "fr-FR",
+      voiceURI: "custom-voice-2"
+    })
+  ];
   
-  // Check structure of region entries
-  for (const region of regions) {
-    t.truthy(region.code);
-    t.truthy(region.label);
-    t.true(typeof region.count === "number");
-  }
+  // Test with provided voices
+  const languages = manager.getLanguages(undefined, undefined, customVoices);
+  
+  t.is(languages.length, 2, "Should return 2 languages");
+  
+  const englishLang = languages.find((l: any) => l.code === "en");
+  const frenchLang = languages.find((l: any) => l.code === "fr");
+  
+  t.is(englishLang?.count, 1, "Should have 1 English voice");
+  t.is(frenchLang?.count, 1, "Should have 1 French voice");
+  t.truthy(englishLang?.label, "Should have English label");
+  t.truthy(frenchLang?.label, "Should have French label");
 });
 
-testWithContext("getRegions: handles empty voices array", async (t: ExecutionContext<TestContext>) => {
-  // Create a fresh instance to avoid interference
-  (WebSpeechVoiceManager as any).instance = undefined;
-  const manager = await WebSpeechVoiceManager.initialize();
+testWithContext("getLanguages: works with provided voices and filters", async (t: ExecutionContext<TestContext>) => {
+  const manager = t.context.manager;
   
-  // Mock empty voices array
-  const emptyMockVoices: any[] = [];
-  const mockSpeechSynthesis = {
-    getVoices: () => emptyMockVoices,
-    onvoiceschanged: null as (() => void) | null,
-    addEventListener: function(event: string, callback: () => void) {
-      if (event === "voiceschanged") {
-        this.onvoiceschanged = callback;
-      }
-    },
-    removeEventListener: function(event: string) {
-    },
-    _triggerVoicesChanged: function() {
-      if (this.onvoiceschanged) {
-        this.onvoiceschanged();
-      }
-    }
-  };
+  // Create custom voices with different qualities
+  const customVoices = [
+    createTestVoice({
+      name: "Custom Voice 1",
+      language: "en-US",
+      voiceURI: "custom-voice-1",
+      quality: "normal"
+    }),
+    createTestVoice({
+      name: "Custom Voice 2",
+      language: "en-US", 
+      voiceURI: "custom-voice-2",
+      quality: "low"
+    })
+  ];
   
-  Object.defineProperty(globalThis.window, "speechSynthesis", {
-    value: mockSpeechSynthesis,
-    configurable: true,
-    writable: true
-  });
+  // Test with provided voices and quality filter
+  const languages = manager.getLanguages(undefined, { quality: ["normal", "high"] }, customVoices);
   
-  try {
-    // Reset initialization
-    (manager as any).initializationPromise = null;
-    (manager as any).voices = [];
-    (manager as any).browserVoices = [];
-    
-    const regions = manager.getRegions();
-    t.deepEqual(regions, []);
-  } finally {
-    // Restore for other tests
-    Object.defineProperty(globalThis.window, "speechSynthesis", {
-      value: {
-        getVoices: () => mockVoices,
-        onvoiceschanged: null as (() => void) | null,
-        addEventListener: function(event: string, callback: () => void) {
-          if (event === "voiceschanged") {
-            this.onvoiceschanged = callback;
-          }
-        },
-        removeEventListener: function(event: string) {
-        },
-        _triggerVoicesChanged: function() {
-          if (this.onvoiceschanged) {
-            this.onvoiceschanged();
-          }
-        }
-      },
-      configurable: true,
-      writable: true
-    });
-  }
+  t.is(languages.length, 1, "Should return 1 language after filtering");
+  t.is(languages[0].count, 1, "Should have 1 voice after filtering");
+  t.is(languages[0].code, "en", "Should be English language");
 });

--- a/test/WebSpeechVoiceManager/getRegions.test.ts
+++ b/test/WebSpeechVoiceManager/getRegions.test.ts
@@ -89,7 +89,7 @@ testWithContext("getRegions: works with provided voices array", async (t: Execut
   ];
   
   // Test with provided voices
-  const regions = manager.getRegions(undefined, customVoices);
+  const regions = manager.getRegions(undefined, undefined, customVoices);
   
   t.is(regions.length, 3, "Should return 3 regions");
   
@@ -123,7 +123,7 @@ testWithContext("getRegions: handles voices without regions", async (t: Executio
   ];
   
   // Test with provided voices (no regions should be extracted)
-  const regions = manager.getRegions(undefined, customVoices);
+  const regions = manager.getRegions(undefined, undefined, customVoices);
   
   t.is(regions.length, 0, "Should return 0 regions when no region codes present");
 });

--- a/test/WebSpeechVoiceManager/getRegions.test.ts
+++ b/test/WebSpeechVoiceManager/getRegions.test.ts
@@ -1,5 +1,5 @@
 import test, { type ExecutionContext } from "ava";
-import { testWithContext, TestContext, originalNavigator, originalSpeechSynthesis, mockSpeechSynthesis } from "./setup.js";
+import { testWithContext, TestContext, originalNavigator, originalSpeechSynthesis, mockSpeechSynthesis, createTestVoice } from "./setup.js";
 import { WebSpeechVoiceManager } from "../../build/index.js";
 
 // =============================================
@@ -64,4 +64,66 @@ testWithContext("getRegions: handles empty voices array", async (t: ExecutionCon
     // Restore original getVoices
     mockSpeechSynthesis.getVoices = originalGetVoices;
   }
+});
+
+testWithContext("getRegions: works with provided voices array", async (t: ExecutionContext<TestContext>) => {
+  const manager = t.context.manager;
+  
+  // Create custom voices with different regions using the helper
+  const customVoices = [
+    createTestVoice({
+      name: "Custom Voice 1",
+      language: "en-US",
+      voiceURI: "custom-voice-1"
+    }),
+    createTestVoice({
+      name: "Custom Voice 2",
+      language: "en-GB", 
+      voiceURI: "custom-voice-2"
+    }),
+    createTestVoice({
+      name: "Custom Voice 3",
+      language: "fr-FR",
+      voiceURI: "custom-voice-3"
+    })
+  ];
+  
+  // Test with provided voices
+  const regions = manager.getRegions(undefined, customVoices);
+  
+  t.is(regions.length, 3, "Should return 3 regions");
+  
+  const usRegion = regions.find((r: any) => r.code === "US");
+  const gbRegion = regions.find((r: any) => r.code === "GB");
+  const frRegion = regions.find((r: any) => r.code === "FR");
+  
+  t.is(usRegion?.count, 1, "Should have 1 US voice");
+  t.is(gbRegion?.count, 1, "Should have 1 GB voice");
+  t.is(frRegion?.count, 1, "Should have 1 FR voice");
+  t.truthy(usRegion?.label, "Should have US label");
+  t.truthy(gbRegion?.label, "Should have GB label");
+  t.truthy(frRegion?.label, "Should have FR label");
+});
+
+testWithContext("getRegions: handles voices without regions", async (t: ExecutionContext<TestContext>) => {
+  const manager = t.context.manager;
+  
+  // Create custom voices without regions (just language codes) using the helper
+  const customVoices = [
+    createTestVoice({
+      name: "Custom Voice 1",
+      language: "en",
+      voiceURI: "custom-voice-1"
+    }),
+    createTestVoice({
+      name: "Custom Voice 2",
+      language: "fr",
+      voiceURI: "custom-voice-2"
+    })
+  ];
+  
+  // Test with provided voices (no regions should be extracted)
+  const regions = manager.getRegions(undefined, customVoices);
+  
+  t.is(regions.length, 0, "Should return 0 regions when no region codes present");
 });

--- a/test/WebSpeechVoiceManager/groupVoices.test.ts
+++ b/test/WebSpeechVoiceManager/groupVoices.test.ts
@@ -35,7 +35,7 @@ testWithContext("groupVoices: groups by language", (t: ExecutionContext<TestCont
     { voiceURI: "voice3", name: "Voice 3", language: "en-US" }
   ];
   
-  const groups = (manager as any).groupVoices(testVoices, "languages");
+  const groups = (manager as any).groupVoices("languages", testVoices);
   
   // Check that groups were created for each language
   t.truthy(groups["en"]);
@@ -57,7 +57,7 @@ testWithContext("groupVoices: groups by gender", (t: ExecutionContext<TestContex
     createTestVoice({ name: "Unknown Voice", language: "es-ES" })
   ];
   
-  const groups = manager.groupVoices(testVoices, "gender");
+  const groups = manager.groupVoices("gender", testVoices);
   t.true(groups.hasOwnProperty("male"));
   t.true(groups.hasOwnProperty("female"));
   t.true(groups.hasOwnProperty("unknown"));
@@ -76,7 +76,7 @@ testWithContext("groupVoices: groups by quality", (t: ExecutionContext<TestConte
     createTestVoice({ name: "High Quality 2", language: "fr-FR", quality: "high" })
   ];
   
-  const groups = manager.groupVoices(testVoices, "quality");
+  const groups = manager.groupVoices("quality", testVoices);
   t.is(Object.keys(groups).length, 2);
   t.is(groups.high.length, 2);
   t.is(groups.low.length, 1);
@@ -93,7 +93,7 @@ testWithContext("groupVoices: groups by region", (t: ExecutionContext<TestContex
     createTestVoice({ name: "Australia Voice", language: "en-AU" })
   ];
   
-  const groups = manager.groupVoices(testVoices, "region");
+  const groups = manager.groupVoices("region", testVoices);
   t.is(Object.keys(groups).length, 4);
   t.is(groups.US.length, 1);
   t.is(groups.GB.length, 1);
@@ -104,7 +104,7 @@ testWithContext("groupVoices: groups by region", (t: ExecutionContext<TestContex
 testWithContext("groupVoices: handles empty voices array", (t: ExecutionContext<TestContext>) => {
   const manager = t.context.manager;
   
-  const groups = manager.groupVoices([], "languages");
+  const groups = manager.groupVoices("languages", []);
   t.deepEqual(groups, {});
 });
 
@@ -119,17 +119,17 @@ testWithContext("groupVoices: handles voices with missing properties", (t: Execu
   ];
   
   // Should handle missing properties gracefully
-  const groupsByLanguage = manager.groupVoices(testVoices, "languages");
+  const groupsByLanguage = manager.groupVoices("languages", testVoices);
   t.true(groupsByLanguage.hasOwnProperty("en"));
   t.true(groupsByLanguage.hasOwnProperty("fr"));
   t.true(groupsByLanguage.hasOwnProperty("es"));
   
-  const groupsByGender = manager.groupVoices(testVoices, "gender");
+  const groupsByGender = manager.groupVoices("gender", testVoices);
   // Should have an "unknown" group for voices without gender
   t.true(groupsByGender.hasOwnProperty("unknown"));
   t.is(groupsByGender.unknown.length, 3); // Voice 2, Voice 3, Voice 4 have no gender
   
-  const groupsByQuality = manager.groupVoices(testVoices, "quality");
+  const groupsByQuality = manager.groupVoices("quality", testVoices);
   // Should have an "unknown" group for voices without quality
   t.true(groupsByQuality.hasOwnProperty("unknown"));
   t.is(groupsByQuality.unknown.length, 3); // Voice 2, Voice 3, Voice 4 have no quality

--- a/test/WebSpeechVoiceManager/initialization.test.ts
+++ b/test/WebSpeechVoiceManager/initialization.test.ts
@@ -65,7 +65,7 @@ testWithContext("initialization: keeps all voices by default", (t) => {
   const basicVoices = (manager as any).parseToReadiumSpeechVoices([lowVoice, normalVoice]);
   t.is(basicVoices.length, 2, "Should keep both basic voices when parsing");
   
-  const basicFiltered = manager.filterVoices({}, basicVoices);
+  const basicFiltered = manager.filterVoices({removeDuplicates: false}, basicVoices);
   t.is(basicFiltered.length, 2, "Should keep both basic voices by default");
   
   // Verify specific voices are preserved
@@ -93,7 +93,7 @@ testWithContext("initialization: keeps all voices by default", (t) => {
   ]);
   t.is(premiumVoices.length, 2, "Should keep both premium voices when parsing");
   
-  const premiumFiltered = manager.filterVoices({}, premiumVoices);
+  const premiumFiltered = manager.filterVoices({removeDuplicates: false}, premiumVoices);
   t.is(premiumFiltered.length, 2, "Should keep both premium voices by default");
   
   // Verify specific voices are preserved
@@ -121,7 +121,7 @@ testWithContext("initialization: keeps all voices by default", (t) => {
   ]);
   t.is(altNameVoices.length, 2, "Should keep both altName voices when parsing");
   
-  const altNameFiltered = manager.filterVoices({}, altNameVoices);
+  const altNameFiltered = manager.filterVoices({removeDuplicates: false}, altNameVoices);
   t.is(altNameFiltered.length, 2, "Should keep both altName voices by default");
   
   // Verify specific voices are preserved
@@ -149,7 +149,7 @@ testWithContext("initialization: keeps all voices by default", (t) => {
   ]);
   t.is(multiAltVoices.length, 2, "Should keep both multi-alt voices when parsing");
   
-  const multiAltFiltered = manager.filterVoices({}, multiAltVoices);
+  const multiAltFiltered = manager.filterVoices({removeDuplicates: false}, multiAltVoices);
   t.is(multiAltFiltered.length, 2, "Should keep both multi-alt voices by default");
   
   // Verify specific voices are preserved

--- a/test/WebSpeechVoiceManager/sortVoices.test.ts
+++ b/test/WebSpeechVoiceManager/sortVoices.test.ts
@@ -94,7 +94,7 @@ testWithContext("sortVoices: sorts by language", (t: ExecutionContext<TestContex
     createTestVoice({ name: "German Voice", language: "de-DE" })
   ];
   
-  const sortedAsc = manager.sortVoicesByLanguages(testVoices);
+const sortedAsc = manager.sortVoicesByLanguages(undefined, testVoices);
   t.is(sortedAsc[0].language, "de-DE");
   t.is(sortedAsc[1].language, "en-US");
   t.is(sortedAsc[2].language, "es-ES");
@@ -116,7 +116,7 @@ testWithContext("sortVoices: sorts languages by preferred", (t: ExecutionContext
   ];
   
   // Test with preferred languages
-  const sortedPreferred = manager.sortVoicesByLanguages(testVoices, ["fr", "en"]);
+  const sortedPreferred = manager.sortVoicesByLanguages(["fr", "en"], testVoices);
   
   // French voices should come first (preferred language)
   t.is(sortedPreferred[0].language, "fr-FR");
@@ -146,7 +146,7 @@ testWithContext("sortVoices: sorts by JSON order", (t: ExecutionContext<TestCont
   ];
   
   // Test with preferred language
-  const sorted = manager.sortVoicesByLanguages(testVoices, ["fr"]);
+  const sorted = manager.sortVoicesByLanguages(["fr"], testVoices);
   
   // Should be in exact JSON order
   t.is(sorted[0].name, "Microsoft VivienneMultilingual Online (Natural) - French (France)");
@@ -167,7 +167,7 @@ testWithContext("sortVoices: sorts by region", (t: ExecutionContext<TestContext>
     createTestVoice({ name: "Australia Voice", language: "en-AU" })
   ];
   
-  const sortedAsc = manager.sortVoicesByRegions(testVoices, []);
+  const sortedAsc = manager.sortVoicesByRegions([], testVoices);
   t.is(sortedAsc[0].language, "en-US");
   t.is(sortedAsc[1].language, "en-AU");
   t.is(sortedAsc[2].language, "en-CA");
@@ -193,7 +193,7 @@ testWithContext("sortVoices: sorts regions by preferred", (t: ExecutionContext<T
   ];
 
   // Test 1: Basic language code should use default region
-  const defaultRegionTest = manager.sortVoicesByRegions(testVoices, ["fr"]);
+  const defaultRegionTest = manager.sortVoicesByRegions(["fr"], testVoices);
 
   // French voices should come first, with fr-FR (default) first
   t.is(defaultRegionTest[0].language, getDefaultRegion("fr"), "Default region should come first");
@@ -201,7 +201,7 @@ testWithContext("sortVoices: sorts regions by preferred", (t: ExecutionContext<T
   t.is(defaultRegionTest[2].language, "fr-CA", "Other French regions should follow alphabetically");
 
   // Test 2: Region inference from other languages
-  const inferredRegionTest = manager.sortVoicesByRegions(testVoices, ["fr", "en-CA"]);
+  const inferredRegionTest = manager.sortVoicesByRegions(["fr", "en-CA"], testVoices);
 
   // fr-CA should come first because en-CA provides the CA region hint
   t.is(inferredRegionTest[0].language, "fr-CA", "Should infer fr-CA from en-CA");
@@ -209,7 +209,7 @@ testWithContext("sortVoices: sorts regions by preferred", (t: ExecutionContext<T
   t.is(inferredRegionTest[2].language, "fr-BE", "Other French regions should follow alphabetically");
 
   // Test 3: Multiple regional preferences
-  const multipleRegionsTest = manager.sortVoicesByRegions(testVoices, ["fr-BE", "fr-CA", "es"]);
+  const multipleRegionsTest = manager.sortVoicesByRegions(["fr-BE", "fr-CA", "es"], testVoices);
 
   // Should respect the order of regional preferences
   t.is(multipleRegionsTest[0].language, "fr-BE", "First regional preference should come first");
@@ -219,7 +219,7 @@ testWithContext("sortVoices: sorts regions by preferred", (t: ExecutionContext<T
   t.is(multipleRegionsTest[4].language, "es-MX", "Other Spanish regions should follow");
 
   // Test 4: Keeping prioritization of regions
-  const prioritizedRegionsTest = manager.sortVoicesByRegions(testVoices, ["en-CA", "fr-BE", "fr-FR"]);
+  const prioritizedRegionsTest = manager.sortVoicesByRegions(["en-CA", "fr-BE", "fr-FR"], testVoices);
 
   // Should respect the exact order of regional preferences
   t.is(prioritizedRegionsTest[0].language, "en-CA", "First explicit preference should be en-CA");
@@ -230,7 +230,7 @@ testWithContext("sortVoices: sorts regions by preferred", (t: ExecutionContext<T
   t.is(prioritizedRegionsTest[5].language, "fr-FR", "French French should come sixth");
 
   // Test 5: Empty/undefined preferred languages (should sort default then alphabetically)
-  const emptyPreferred = manager.sortVoicesByRegions(testVoices, []);
+  const emptyPreferred = manager.sortVoicesByRegions([], testVoices);
   t.is(emptyPreferred[0].language, "de-DE");
   t.is(emptyPreferred[1].language, "en-US");
   t.is(emptyPreferred[2].language, "en-CA");
@@ -259,7 +259,7 @@ testWithContext("sortVoices: sorts regions by JSON order", (t: ExecutionContext<
   ];
   
   // Test with preferred language
-  const sorted = manager.sortVoicesByRegions(testVoices, ["fr-FR"]);
+  const sorted = manager.sortVoicesByRegions(["fr-FR"], testVoices);
   
   // Should be in exact JSON order for same quality, then quality ordering
   t.is(sorted[0].name, "Microsoft VivienneMultilingual Online (Natural) - French (France)");


### PR DESCRIPTION
This PR addresses ChromeOS-specific issues: deduplicating of voices, ordering of voices based on JSON quality order. It also introduces a new debug page for dev convenience, whose purpose is to mock ChromeOS `speechSynthesis` so that you do not necessarily need a device running it to debug Voice management. 

Note this redesigns how ReadiumSpeechVoices are handled internally by the `Manager` instance, as it will keep all parsed voices in memory. You can use a filtered array and pass it to each method if you do not need to filter, sort, or group all of them. This has the unfortunate side effect of requiring further work for code-splitting tho, which will be addressed in another PR. 