### PR TITLE
Server support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] - 2026-07-31
+
+### Added
+
+- `SpeechServerEngine` / `SpeechServerEngineProvider`, a second `ReadiumSpeechPlaybackEngine` implementation backed by a [Readium Speech Server](https://github.com/readium/speech-server) HTTP service — with utterance prefetching, chunk-streaming for long/over-limit utterances, gapless Web Audio API scheduling, format/bitrate selection, and RFC 9457 error handling. See [SpeechServerEngine.md](docs/SpeechServerEngine.md).
+- `ReadiumSpeechProviderRegistry`, for registering multiple `ReadiumSpeechEngineProvider`s (e.g. WebSpeech and speech-server) side by side and querying voices/creating engines across all of them. See [ProviderRegistry.md](docs/ProviderRegistry.md).
+- `ReadiumSpeechVoice.identifier` and `ReadiumSpeechVoice.controls` (which playback controls a server-sourced voice actually honors), and `"server"` added to `TSource`.
+
+### Changed
+
+- `ReadiumSpeechNavigator` (renamed from `WebSpeechReadAloudNavigator`) is now engine-agnostic: its constructor requires an explicit `ReadiumSpeechPlaybackEngine` (e.g. `new ReadiumSpeechNavigator(new WebSpeechEngine())`), instead of defaulting to WebSpeech.
+- `WebSpeechEngineProvider.getVoices()` no longer requires an engine to have been created first.
+
 ## [0.4.0] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The outline of this work has been explored in a [GitHub discussion](https://gith
 In the second phase, we focused on implementing a WebSpeech API-based solution with an architecture designed for future extensibility:
 
 - **Engine Layer**: Core TTS functionality through `ReadiumSpeechPlaybackEngine`
-- **Navigator Layer**: Content and playback management via (a temporary) `ReadiumSpeechNavigator`
+- **Navigator Layer**: Content and playback management via `ReadiumSpeechNavigator`
 - **Current Implementation**: WebSpeech API with cross-browser compatibility
 - **Future-Proof Design**: Architecture prepared for additional TTS service adapters
 
@@ -32,7 +32,9 @@ Key features include advanced voice selection, cross-browser playback control, f
 
 In the third phase, we added highlighting: content currently being spoken (e.g. the current word or sentence) can be highlighted as playback progresses. See the [Highlighting guide](docs/Highlighting.md).
 
-We are now focused on the fourth phase: extracting [Guided Navigation objects](https://readium.org/guided-navigation) from a document (or a fragment of a document), and generating utterances from these objects.
+In the fourth phase, we extracted [Guided Navigation objects](https://readium.org/guided-navigation) from a document (or a fragment of a document), and generated utterances from these objects.
+
+We are now on the fifth phase: a second `ReadiumSpeechPlaybackEngine` implementation, backed by [speech-server](https://github.com/readium/speech-server) instead of the browser's Web Speech API.
 
 ## Demos
 
@@ -78,7 +80,8 @@ yarn add @readium/speech
 ```typescript
 import {
   WebSpeechVoiceManager,
-  WebSpeechReadAloudNavigator,
+  WebSpeechEngine,
+  ReadiumSpeechNavigator,
   setupDecorations,
   DecorationStyleType,
 } from "@readium/speech";
@@ -92,7 +95,7 @@ const voiceManager = await WebSpeechVoiceManager.initialize({
 const voice = await voiceManager.getDefaultVoice("en-US");
 
 // Create a navigator instance
-const navigator = new WebSpeechReadAloudNavigator();
+const navigator = new ReadiumSpeechNavigator(new WebSpeechEngine());
 await navigator.setVoice(voice);
 
 const content = document.getElementById("content");
@@ -137,6 +140,7 @@ Documentation provides guides for:
 - [Highlighting](docs/Highlighting.md)
 - [Guided Navigation](docs/GuidedNavigation.md) — extracting [Guided Navigation objects](https://readium.org/guided-navigation) from HTML/XHTML content
 - [Utterance Extraction](docs/UtteranceExtraction.md) — extracting utterances from Guided Navigation objects
+- [Provider Registry](docs/ProviderRegistry.md) — using more than one `ReadiumSpeechEngineProvider` (e.g. WebSpeech and speech-server) side by side
 
 ## Development
 

--- a/demo/article/script.js
+++ b/demo/article/script.js
@@ -1,4 +1,4 @@
-import { WebSpeechVoiceManager, WebSpeechReadAloudNavigator, setupDecorations, DecorationStyleType } from "../../build/index.js";
+import { WebSpeechVoiceManager, WebSpeechEngine, ReadiumSpeechNavigator, setupDecorations, DecorationStyleType } from "../../build/index.js";
 
 // Set up the Decorator for TTS word highlights
 const decoCtrl = setupDecorations();
@@ -34,7 +34,7 @@ async function initialize() {
     enVoices = await voiceManager.getVoices({removeDuplicates: true});
     
     // Initialize the navigator
-    navigator = new WebSpeechReadAloudNavigator();
+    navigator = new ReadiumSpeechNavigator(new WebSpeechEngine());
     
     // Set up event listeners
     setupEventListeners();

--- a/demo/playground/script.js
+++ b/demo/playground/script.js
@@ -21,10 +21,11 @@ const speechResumeEl = document.getElementById("speech-resume");
 const speechStopEl = document.getElementById("speech-stop");
 
 // Feature-detect the GND converter, the utterance extractor, and the
-// WebSpeech read-aloud navigator, if/when @readium/speech exports them.
+// read-aloud navigator, if/when @readium/speech exports them.
 let converter = null;
 let utteranceExtractor = null;
 let NavigatorClass = null;
+let EngineClass = null;
 let VoiceManagerClass = null;
 let setupDecorations = null;
 let DecorationStyleType = null;
@@ -36,8 +37,11 @@ try {
   if (typeof mod.extractUtterances === "function") {
     utteranceExtractor = mod;
   }
-  if (typeof mod.WebSpeechReadAloudNavigator === "function") {
-    NavigatorClass = mod.WebSpeechReadAloudNavigator;
+  if (typeof mod.ReadiumSpeechNavigator === "function") {
+    NavigatorClass = mod.ReadiumSpeechNavigator;
+  }
+  if (typeof mod.WebSpeechEngine === "function") {
+    EngineClass = mod.WebSpeechEngine;
   }
   if (typeof mod.WebSpeechVoiceManager === "function") {
     VoiceManagerClass = mod.WebSpeechVoiceManager;
@@ -244,7 +248,7 @@ function setBadge(el, state) {
 // extraction without refetching the fixture's files.
 let currentFixture = null;
 
-// WebSpeechReadAloudNavigator wraps the playback engine and handles
+// ReadiumSpeechNavigator wraps the playback engine and handles
 // advancing through the queued utterances on its own — created once, lazily
 // (its constructor kicks off async engine/voice initialization), not per
 // fixture/option change.
@@ -329,10 +333,10 @@ let voiceReadyPromise = null;
 const PLAYGROUND_LANGUAGES = ["en", "es", "fr"];
 
 function ensurePlaybackNavigator() {
-  if (!NavigatorClass) return null;
+  if (!NavigatorClass || !EngineClass) return null;
   if (!playbackNavigator) {
     void VoiceManagerClass?.initialize({ languages: PLAYGROUND_LANGUAGES });
-    playbackNavigator = new NavigatorClass();
+    playbackNavigator = new NavigatorClass(new EngineClass());
     playbackNavigator.setSpeakInContentLanguage(true);
     for (const type of ["start", "pause", "resume", "end", "stop", "ready", "error"]) {
       playbackNavigator.on(type, syncSpeechUi);

--- a/demo/script.js
+++ b/demo/script.js
@@ -1,4 +1,4 @@
-import { WebSpeechVoiceManager, WebSpeechReadAloudNavigator, chineseVariantMap, setupDecorations, DecorationStyleType } from "../build/index.js";
+import { WebSpeechVoiceManager, WebSpeechEngine, ReadiumSpeechNavigator, chineseVariantMap, setupDecorations, DecorationStyleType } from "../build/index.js";
 
 // Set up the Decorator for TTS word highlights
 const decoCtrl = setupDecorations();
@@ -35,7 +35,7 @@ let testUtterance = "";
 let userCustomUtterance = "";
 let lastNavigatorPosition = 1;
 
-const speechNavigator = new WebSpeechReadAloudNavigator();
+const speechNavigator = new ReadiumSpeechNavigator(new WebSpeechEngine());
 
 // Set up event listeners for the navigator
 speechNavigator.on("boundary", (event) => {

--- a/docs/Playback.md
+++ b/docs/Playback.md
@@ -1,16 +1,18 @@
 # Playback API
 
-The playback API is a high-level API that provides a simple interface for playing, pausing, and stopping speech. It relies on an engine that you provide to it, or fallback to WebSpeech if none is provided.
+The playback API is a high-level API that provides a simple interface for playing, pausing, and stopping speech. `ReadiumSpeechNavigator` wraps a `ReadiumSpeechPlaybackEngine` that you provide — e.g. `WebSpeechEngine` or `SpeechServerEngine`.
 
 Once initialized, you can use the navigator to load content (utterances) and control playback.
 
 ## ReadiumSpeechNavigator
 
+`ReadiumSpeechNavigator` implements `ReadiumSpeechNavigatorContract`:
+
 ```typescript
-interface ReadiumSpeechNavigator {
+interface ReadiumSpeechNavigatorContract {
   // Voice Management
   getVoices(): Promise<ReadiumSpeechVoice[]>;
-  setVoice(voice: ReadiumSpeechVoice | string): Promise<void>;
+  setVoice(voice: ReadiumSpeechVoice | string): void;
   getCurrentVoice(): ReadiumSpeechVoice | null;
   setSpeakInContentLanguage(enabled: boolean): void;
   getSpeakInContentLanguage(): boolean;
@@ -40,25 +42,24 @@ interface ReadiumSpeechNavigator {
   
   // State
   getState(): ReadiumSpeechPlaybackState;
-  getCurrentUtteranceIndex(): number;
   
   // Events
   on(
-    event: ReadiumSpeechPlaybackEvent["type"],
+    event: ReadiumSpeechPlaybackEvent["type"] | "contentchange",
     listener: (event: ReadiumSpeechPlaybackEvent) => void
-  ): void;
+  ): () => void;
   
-  // Cleanup
-  destroy(): void;
+  // Lifecycle
+  destroy(): Promise<void>;
 }
 ```
 
 ### Example Usage
 
 ```typescript
-import { WebSpeechReadAloudNavigator } from "@readium/speech";
+import { WebSpeechEngine, ReadiumSpeechNavigator } from "@readium/speech";
 
-const navigator = new WebSpeechReadAloudNavigator();
+const navigator = new ReadiumSpeechNavigator(new WebSpeechEngine());
 
 navigator.loadContent([
   { plain: "Hello world.", language: "en" }

--- a/docs/Playback.md
+++ b/docs/Playback.md
@@ -1,6 +1,6 @@
 # Playback API
 
-The playback API is a high-level API that provides a simple interface for playing, pausing, and stopping speech. `ReadiumSpeechNavigator` wraps a `ReadiumSpeechPlaybackEngine` that you provide — e.g. `WebSpeechEngine` or `SpeechServerEngine`.
+The playback API is a high-level API that provides a simple interface for playing, pausing, and stopping speech. `ReadiumSpeechNavigator` wraps a `ReadiumSpeechPlaybackEngine` that you provide — e.g. [`WebSpeechEngine`](WebSpeechEngine.md) or [`SpeechServerEngine`](SpeechServerEngine.md), each documented separately for construction/options; this page covers the shared engine contract and navigator API.
 
 Once initialized, you can use the navigator to load content (utterances) and control playback.
 

--- a/docs/ProviderRegistry.md
+++ b/docs/ProviderRegistry.md
@@ -1,0 +1,80 @@
+# Provider Registry
+
+`@readium/speech` now ships two `ReadiumSpeechEngineProvider` implementations — [`WebSpeechEngineProvider`](WebSpeech.md) (the browser's built-in TTS) and `SpeechServerEngineProvider` (a remote TTS HTTP service). An app that only ever uses one of them doesn't need anything beyond that provider directly:
+
+```ts
+const provider = new WebSpeechEngineProvider();
+const engine = await provider.createEngine();
+```
+
+`ReadiumSpeechProviderRegistry` ([src/providerRegistry.ts](../src/providerRegistry.ts)) is for the case where an app wants **more than one provider available at once** — e.g. offering the user a choice between the device's own voices and a set of higher-quality server-hosted ones, or falling back to WebSpeech when no speech-server is configured. It's a small lookup table from provider id to provider instance, plus a couple of conveniences for working across all of them at once. Skip it entirely if your app only ever uses one provider.
+
+## Why voices aren't merged into one list
+
+It's tempting to want `registry.getAllVoices()` to return one flat `ReadiumSpeechVoice[]` so it can be dropped straight into a `<select>`. It deliberately doesn't, because there's no way to route a voice back to the provider that produced it once it's out of context: `ReadiumSpeechVoice.provider` already means something else per source (unset for WebSpeech, the *backend inside* speech-server — e.g. `"pocket"` — for server voices), not the registry id you'd need to call `createEngine()` again.
+
+So the registry keeps voices grouped by provider id, and leaves flattening (if a single UI list is wanted) to the caller, who is then also responsible for remembering which provider a picked voice came from.
+
+## API
+
+```ts
+class ReadiumSpeechProviderRegistry {
+  register(provider: ReadiumSpeechEngineProvider): void;   // throws if the id is already registered
+  unregister(providerId: string): void;
+  get(providerId: string): ReadiumSpeechEngineProvider | undefined;
+  list(): ReadiumSpeechEngineProvider[];
+
+  getVoices(providerId: string): Promise<ReadiumSpeechVoice[]>;
+  getAllVoices(): Promise<{ providerId: string; voices: ReadiumSpeechVoice[] }[]>;
+
+  createEngine(providerId: string, voice?: ReadiumSpeechVoice | string): Promise<ReadiumSpeechPlaybackEngine>;
+  destroy(): Promise<void>; // destroys every registered provider, then clears the registry
+}
+```
+
+## Example: a voice picker across both providers
+
+```ts
+import {
+  ReadiumSpeechProviderRegistry,
+  WebSpeechEngineProvider,
+  SpeechServerEngineProvider,
+  ReadiumSpeechNavigator
+} from "@readium/speech";
+
+const registry = new ReadiumSpeechProviderRegistry();
+registry.register(new WebSpeechEngineProvider());
+registry.register(new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000" }));
+
+// [{ providerId: "webspeech", voices }, { providerId: "speech-server", voices }]
+const grouped = await registry.getAllVoices();
+
+// Render as two labeled groups (e.g. <optgroup>), tracking providerId alongside each choice.
+for (const { providerId, voices } of grouped) {
+  renderVoiceGroup(providerId, voices);
+}
+
+// Once the user picks a (providerId, voice) pair:
+async function onVoicePicked(providerId: string, voice: ReadiumSpeechVoice) {
+  const engine = await registry.createEngine(providerId, voice);
+  const navigator = new ReadiumSpeechNavigator(engine);
+  navigator.loadContent([{ plain: "Hello world" }]);
+  navigator.play();
+}
+```
+
+## Falling back when a provider isn't available
+
+`register()` doesn't validate that a provider actually works (e.g. that a speech-server is reachable) — that only surfaces the first time `getVoices()`/`createEngine()` is called and the request fails. Check reachability yourself before registering if you need a clean fallback:
+
+```ts
+const registry = new ReadiumSpeechProviderRegistry();
+registry.register(new WebSpeechEngineProvider());
+
+try {
+  await fetch("http://localhost:8000/readyz");
+  registry.register(new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000" }));
+} catch {
+  // No speech-server reachable — registry.list() only has "webspeech".
+}
+```

--- a/docs/ProviderRegistry.md
+++ b/docs/ProviderRegistry.md
@@ -1,6 +1,6 @@
 # Provider Registry
 
-`@readium/speech` now ships two `ReadiumSpeechEngineProvider` implementations — [`WebSpeechEngineProvider`](WebSpeech.md) (the browser's built-in TTS) and `SpeechServerEngineProvider` (a remote TTS HTTP service). An app that only ever uses one of them doesn't need anything beyond that provider directly:
+`@readium/speech` now ships two `ReadiumSpeechEngineProvider` implementations — [`WebSpeechEngineProvider`](WebSpeechEngine.md) (the browser's built-in TTS) and [`SpeechServerEngineProvider`](SpeechServerEngine.md) (a remote TTS HTTP service). An app that only ever uses one of them doesn't need anything beyond that provider directly — see each engine's doc for its full options reference:
 
 ```ts
 const provider = new WebSpeechEngineProvider();
@@ -44,7 +44,13 @@ import {
 
 const registry = new ReadiumSpeechProviderRegistry();
 registry.register(new WebSpeechEngineProvider());
-registry.register(new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000" }));
+registry.register(new SpeechServerEngineProvider({
+  endpoints: {
+    voices: "http://localhost:8000/voices",
+    synthesize: "http://localhost:8000/synthesize",
+    service: "http://localhost:8000/service"
+  }
+}));
 
 // [{ providerId: "webspeech", voices }, { providerId: "speech-server", voices }]
 const grouped = await registry.getAllVoices();
@@ -73,7 +79,13 @@ registry.register(new WebSpeechEngineProvider());
 
 try {
   await fetch("http://localhost:8000/readyz");
-  registry.register(new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000" }));
+  registry.register(new SpeechServerEngineProvider({
+    endpoints: {
+      voices: "http://localhost:8000/voices",
+      synthesize: "http://localhost:8000/synthesize",
+      service: "http://localhost:8000/service"
+    }
+  }));
 } catch {
   // No speech-server reachable — registry.list() only has "webspeech".
 }

--- a/docs/SpeechServerEngine.md
+++ b/docs/SpeechServerEngine.md
@@ -70,3 +70,14 @@ By default the engine picks a format from the intersection of what the server ad
 ## Errors
 
 Failures surface as `"error"` events (see [Playback.md](Playback.md#readiumspeechplaybackevent)), with `detail` shaped like a `SpeechServerError`: `{ message, status, type, title, instance }`, following [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) when the server returns one.
+
+## Minimizing gaps between utterances
+
+- **Gapless scheduling**: chunks/utterances are decoded into `AudioBuffer`s and scheduled back-to-back on one continuous `AudioContext` timeline (`node.start(t)`, with `t` advanced by each buffer's own duration) rather than played one at a time via sequential `<audio>` elements — there's no stop/start gap between them.
+- **Prefetching ahead**: while an utterance plays, the engine fetches up to `prefetchWindow` upcoming utterances so they're already decoded by the time playback reaches them. Requests are chained one at a time (never more than one `/synthesize` in flight), so this doesn't compete with `maxConcurrentSyntheses` on the server.
+- **Buffering before "ready"**: `readyBufferChars` holds off the `"ready"` event until enough of the front of the queue is prefetched, so playback doesn't immediately outrun an empty buffer right after the first utterance starts.
+- **Chunk-level streaming for long utterances**: when `overLengthText: "split"` breaks an utterance into multiple requests, playback starts on the first chunk as soon as it's ready — it doesn't wait for the rest — while later chunks keep fetching and get scheduled onto the same gapless timeline as they resolve. Callers still only see a single `"start"`/`"end"` pair for the whole utterance, not one per chunk.
+
+## Known limitations
+
+`/synthesize` returns a complete base64-encoded audio payload per request, not a stream — the engine waits for the full response, then decodes it whole via `AudioContext.decodeAudioData`. There's no Media Source Extensions (MSE) usage and no incremental playback within a single chunk. `prefetchWindow`/`readyBufferChars`/`overLengthText: "split"` reduce the perceived gap between utterances by overlapping requests and keeping individual requests small, but a single long chunk still has to finish downloading before any of it can play.

--- a/docs/SpeechServerEngine.md
+++ b/docs/SpeechServerEngine.md
@@ -1,0 +1,72 @@
+# SpeechServerEngine
+
+`SpeechServerEngine` implements `ReadiumSpeechPlaybackEngine` (see [Playback.md](Playback.md)) against a remote TTS HTTP service — a [Readium Speech Server](https://github.com/readium/speech-server) instance. `SpeechServerEngineProvider` wraps it for use with a single provider or [`ReadiumSpeechProviderRegistry`](ProviderRegistry.md).
+
+## Construction
+
+Via the provider (recommended — handles voice caching for you):
+
+```ts
+import { SpeechServerEngineProvider } from "@readium/speech";
+
+const provider = new SpeechServerEngineProvider({
+  endpoints: {
+    voices: "http://localhost:8000/voices",
+    synthesize: "http://localhost:8000/synthesize",
+    service: "http://localhost:8000/service"
+  }
+});
+const engine = await provider.createEngine();
+```
+
+Directly, if you don't need the registry or provider-level voice caching:
+
+```ts
+import { SpeechServerEngine } from "@readium/speech";
+
+const engine = new SpeechServerEngine({
+  endpoints: { voices: "...", synthesize: "...", service: "..." }
+});
+```
+
+`SpeechServerEngineProviderOptions` is the same shape as `SpeechServerEngineOptions` below — every option documented here works identically through either constructor.
+
+## Options
+
+```ts
+interface SpeechServerEngineOptions {
+  endpoints: {
+    voices: string;      // GET  — list available voices
+    synthesize: string;  // POST — synthesize one utterance/chunk
+    service: string;     // GET  — server capabilities (formats, maxTextLength, ...)
+  };
+  fetch?: typeof fetch;         // default: fetch bound to globalThis
+  prefetchWindow?: number;      // utterances to keep pre-fetched ahead of playback, default 3
+  readyBufferChars?: number;    // combined chars to buffer before "ready", default 400
+  overLengthText?: "split" | "error"; // default "split"
+  format?: SpeechServerFormatOptions;
+}
+```
+
+- `prefetchWindow`: buffer depth, not concurrency — requests are chained one at a time, never more than one `/synthesize` in flight.
+- `readyBufferChars`: bounded by `prefetchWindow` too — the initial buffer is just the front of that same lookahead.
+- `overLengthText`: an utterance longer than the server's advertised `maxTextLength` (from `/service`) is split into multiple `/synthesize` requests and played back-to-back as one logical utterance by default (`"split"`). Set `"error"` to instead fail fast with a `SpeechServerError` (413, `payload_too_large`) — e.g. if you'd rather pre-chunk text yourself upstream. Splitting is sentence/word-boundary-aware for plain text, and tag-atomic for SSML (never cuts inside a `<tag>...</tag>` span).
+- `format`: see below.
+
+## Format selection
+
+```ts
+interface SpeechServerFormatOptions {
+  preferredFormat?: string;         // e.g. "opus" — used only if advertised + browser-playable
+  strategy?: "quality" | "bandwidth"; // default "quality"
+  adaptBitrateToNetwork?: boolean;  // default false
+}
+```
+
+By default the engine picks a format from the intersection of what the server advertises (`/service`'s `output.formats`) and what the browser can actually decode (`HTMLAudioElement.canPlayType`), ranked `"quality"` (lossless/higher-fidelity first) or `"bandwidth"` (smallest-transfer first). `preferredFormat` overrides that ranking outright, as long as it's both advertised and playable — an unsupported preference is silently ignored rather than erroring.
+
+`adaptBitrateToNetwork` reduces the requested bitrate for compressed formats when the browser's Network Information API (`navigator.connection`, Chromium-only) reports Save-Data or a 2G-class connection. It's opt-in and off by default, since that API doesn't exist in every browser and this must never silently change behavior for callers who didn't ask for it.
+
+## Errors
+
+Failures surface as `"error"` events (see [Playback.md](Playback.md#readiumspeechplaybackevent)), with `detail` shaped like a `SpeechServerError`: `{ message, status, type, title, instance }`, following [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) when the server returns one.

--- a/docs/WebSpeechEngine.md
+++ b/docs/WebSpeechEngine.md
@@ -1,0 +1,45 @@
+# WebSpeechEngine
+
+`WebSpeechEngine` implements `ReadiumSpeechPlaybackEngine` (see [Playback.md](Playback.md)) against the browser's built-in [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API). `WebSpeechEngineProvider` wraps it for use with a single provider or [`ReadiumSpeechProviderRegistry`](ProviderRegistry.md).
+
+For platform-specific quirks and voice behavior across browsers/OSes, see [WebSpeech.md](WebSpeech.md).
+
+## Construction
+
+Via the provider — always calls `initialize()` with no options, so use this only when you're fine with the defaults below:
+
+```ts
+import { WebSpeechEngineProvider } from "@readium/speech";
+
+const provider = new WebSpeechEngineProvider();
+const engine = await provider.createEngine();
+```
+
+Directly, when you need to pass options:
+
+```ts
+import { WebSpeechEngine } from "@readium/speech";
+
+const engine = new WebSpeechEngine();
+await engine.initialize({
+  languages: ["en", "fr"],
+  maxLengthExceeded: "error" // default is "warn" — override to fail fast instead
+});
+```
+
+## `initialize()` options
+
+```ts
+async initialize(options?: {
+  languages?: string[];
+  maxTimeout?: number;
+  interval?: number;
+  maxLengthExceeded?: "error" | "none" | "warn";
+}): Promise<boolean>
+```
+
+`languages`, `maxTimeout`, and `interval` are forwarded as-is to `WebSpeechVoiceManager.initialize()` — see [VoiceManagement.md](VoiceManagement.md#initialize-the-voice-manager) for what each does.
+
+`maxLengthExceeded` (default `"warn"`) controls what happens when an utterance's text exceeds the Web Speech API's practical length limit: `"warn"` logs a console warning and speaks anyway, `"error"` throws, `"none"` does nothing and speaks anyway. Unlike `SpeechServerEngine`'s `overLengthText: "split"` (see [SpeechServerEngine.md](SpeechServerEngine.md)), there is no splitting behavior here — the Web Speech API has no equivalent server-side request-size constraint to work around, just an engine-dependent practical ceiling.
+
+Calling `initialize()` again on an already-initialized engine is a no-op (`false`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/speech",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A TypeScript library for implementing read aloud features with Web technologies, following best practices for digital publishing.",
   "author": "Readium Foundation",
   "keywords": [

--- a/src/SpeechServer/chunkText.ts
+++ b/src/SpeechServer/chunkText.ts
@@ -1,0 +1,140 @@
+import { BINDING_PUNCT_CLASS } from "../utils/text";
+
+export interface TextChunk {
+  text: string;
+  offset: number;
+}
+
+interface Atom {
+  text: string;
+  offset: number;
+  // Atomic atoms (SSML tag spans) are never split, even if they exceed maxLength alone.
+  atomic: boolean;
+}
+
+// Greedily packs atoms into chunks up to maxLength; an atom exceeding maxLength alone is
+// still emitted as its own oversized chunk rather than dropped or corrupted.
+function packAtoms(atoms: Atom[], maxLength: number): TextChunk[] {
+  const chunks: TextChunk[] = [];
+  let bufferStart = -1;
+  let bufferEnd = -1;
+
+  const flush = (): void => {
+    if (bufferStart !== -1) {
+      chunks.push({ text: sliceAtoms(atoms, bufferStart, bufferEnd), offset: atoms[bufferStart].offset });
+      bufferStart = -1;
+      bufferEnd = -1;
+    }
+  };
+
+  for (let i = 0; i < atoms.length; i++) {
+    const atom = atoms[i];
+
+    if (atom.text.length > maxLength) {
+      flush();
+      chunks.push({ text: atom.text, offset: atom.offset });
+      continue;
+    }
+
+    const atomEnd = atom.offset + atom.text.length;
+    const wouldBeLength = bufferStart === -1 ? atom.text.length : atomEnd - atoms[bufferStart].offset;
+    if (bufferStart !== -1 && wouldBeLength > maxLength) {
+      flush();
+    }
+
+    if (bufferStart === -1) {
+      bufferStart = i;
+    }
+    bufferEnd = i;
+  }
+  flush();
+
+  return chunks;
+}
+
+function sliceAtoms(atoms: Atom[], start: number, end: number): string {
+  const first = atoms[start];
+  const last = atoms[end];
+  return first === last ? first.text : atoms.slice(start, end + 1).map(a => a.text).join("");
+}
+
+// Splits on the same Unicode-aware binding-punctuation class used elsewhere in this codebase
+// (src/utils/text.ts) — CJK/Arabic terminators included, not just ASCII .!?. Trailing
+// whitespace is absorbed when present but not required, since CJK sentences run together.
+const SENTENCE_RE = new RegExp(
+  `[^${BINDING_PUNCT_CLASS}]*[${BINDING_PUNCT_CLASS}]+\\s*|[^${BINDING_PUNCT_CLASS}]+$`,
+  "gu"
+);
+
+// Splits on whitespace runs, keeping trailing whitespace attached to the preceding word so
+// offsets/reconstruction stay exact.
+const WORD_RE = /\S+\s*|\s+/g;
+
+function tokenize(text: string, offset: number, regex: RegExp): Atom[] {
+  const atoms: Atom[] = [];
+  for (const match of text.matchAll(regex)) {
+    if (match[0].length === 0) continue;
+    atoms.push({ text: match[0], offset: offset + match.index, atomic: false });
+  }
+  return atoms;
+}
+
+// Re-splits an over-long atom one level down (sentence -> word -> hard character split).
+function expandOverLongAtom(atom: Atom, maxLength: number): Atom[] {
+  if (atom.text.length <= maxLength || atom.atomic) {
+    return [atom];
+  }
+  const words = tokenize(atom.text, atom.offset, WORD_RE);
+  if (words.length > 1) {
+    return words.flatMap(word => expandOverLongAtom(word, maxLength));
+  }
+  // No whitespace to split on — hard split as a last resort, walking whole code points (not
+  // raw UTF-16 indices) so a surrogate pair (e.g. an emoji) is never torn in half.
+  const hardSplit: Atom[] = [];
+  let sliceOffset = atom.offset;
+  let sliceText = "";
+  for (const char of atom.text) {
+    if (sliceText.length > 0 && sliceText.length + char.length > maxLength) {
+      hardSplit.push({ text: sliceText, offset: sliceOffset, atomic: false });
+      sliceOffset += sliceText.length;
+      sliceText = "";
+    }
+    sliceText += char;
+  }
+  if (sliceText.length > 0) {
+    hardSplit.push({ text: sliceText, offset: sliceOffset, atomic: false });
+  }
+  return hardSplit;
+}
+
+export function chunkPlainText(text: string, maxLength: number): TextChunk[] {
+  if (text.length <= maxLength) {
+    return [{ text, offset: 0 }];
+  }
+  const sentences = tokenize(text, 0, SENTENCE_RE);
+  const atoms = sentences.flatMap(sentence => expandOverLongAtom(sentence, maxLength));
+  return packAtoms(atoms, maxLength);
+}
+
+// Matches a complete `<tag>...</tag>` span (SSML fragments here are always flat, never
+// nested) or a self-closing `<tag/>` as one atomic unit; everything else is plain text.
+const SSML_TOKEN_RE = /<([a-zA-Z][\w-]*)\b[^>]*>[\s\S]*?<\/\1>|<[a-zA-Z][\w-]*\b[^>]*\/>|[^<]+/g;
+
+export function chunkSsmlText(text: string, maxLength: number): TextChunk[] {
+  if (text.length <= maxLength) {
+    return [{ text, offset: 0 }];
+  }
+
+  const atoms: Atom[] = [];
+  for (const match of text.matchAll(SSML_TOKEN_RE)) {
+    const isTag = match[0][0] === "<";
+    if (isTag) {
+      atoms.push({ text: match[0], offset: match.index, atomic: true });
+    } else {
+      atoms.push(...tokenize(match[0], match.index, SENTENCE_RE));
+    }
+  }
+
+  const expanded = atoms.flatMap(atom => expandOverLongAtom(atom, maxLength));
+  return packAtoms(expanded, maxLength);
+}

--- a/src/SpeechServer/errors.ts
+++ b/src/SpeechServer/errors.ts
@@ -1,0 +1,43 @@
+export interface SpeechServerProblemDetails {
+  type: string;
+  title: string;
+  status: number;
+  detail: string;
+  instance?: string;
+}
+
+export class SpeechServerError extends Error {
+  readonly status: number;
+  readonly type?: string;
+  readonly title?: string;
+  readonly instance?: string;
+
+  constructor(message: string, options: { status: number; type?: string; title?: string; instance?: string }) {
+    super(message);
+    this.name = "SpeechServerError";
+    this.status = options.status;
+    this.type = options.type;
+    this.title = options.title;
+    this.instance = options.instance;
+  }
+}
+
+// Server errors are RFC 9457 Problem Details, but nginx (production rate/connection
+// limits) and network failures return plain text or nothing, so parsing is best-effort.
+export async function toSpeechServerError(response: Response): Promise<SpeechServerError> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/problem+json")) {
+    try {
+      const problem: SpeechServerProblemDetails = await response.json();
+      return new SpeechServerError(problem.detail || problem.title || `Request failed with status ${response.status}`, {
+        status: problem.status ?? response.status,
+        type: problem.type,
+        title: problem.title,
+        instance: problem.instance
+      });
+    } catch {
+      // Fall through to the generic error below.
+    }
+  }
+  return new SpeechServerError(`Request failed with status ${response.status}`, { status: response.status });
+}

--- a/src/SpeechServer/index.ts
+++ b/src/SpeechServer/index.ts
@@ -1,3 +1,5 @@
+export * from "./chunkText";
+export * from "./selectFormat";
 export * from "./speechServerEngine";
 export * from "./speechServerEngineProvider";
 export * from "./speechServerVoiceMapping";

--- a/src/SpeechServer/index.ts
+++ b/src/SpeechServer/index.ts
@@ -1,0 +1,5 @@
+export * from "./speechServerEngine";
+export * from "./speechServerEngineProvider";
+export * from "./speechServerVoiceMapping";
+export * from "./errors";
+export * from "./types";

--- a/src/SpeechServer/selectFormat.ts
+++ b/src/SpeechServer/selectFormat.ts
@@ -1,0 +1,93 @@
+import { SpeechServerAudioFormat } from "./types";
+
+// Mirrors HTMLAudioElement.canPlayType's return type exactly, so this module stays decoupled
+// from lib.dom and is callable with a fake predicate in non-browser test environments.
+export type CanPlayTypeResult = "probably" | "maybe" | "";
+export type CanPlayType = (mime: string) => CanPlayTypeResult;
+
+// Operates on plain `string`, not the narrower SpeechServerAudioFormat union, so an
+// unrecognized format is still handled rather than mislabeled or dropped.
+const MIME_TYPES: Record<string, string> = {
+  wav: "audio/wav",
+  mp3: "audio/mpeg",
+  opus: "audio/ogg",
+  ogg: "audio/ogg",
+  aac: "audio/aac",
+  flac: "audio/flac",
+  webm: "audio/webm",
+  m4a: "audio/mp4"
+};
+
+export function mimeTypeForFormat(format: string): string {
+  return MIME_TYPES[format] ?? `audio/${format}`;
+}
+
+export interface SpeechServerFormatOptions {
+  // Used only if the server advertises it and canPlay() reports it playable; else falls back
+  // to automatic selection below.
+  preferredFormat?: SpeechServerAudioFormat | (string & {});
+  // Ranks the playable intersection when no preferredFormat wins: "quality" (default) prefers
+  // lossless/higher-fidelity first; "bandwidth" prefers smaller-transfer first.
+  strategy?: "quality" | "bandwidth";
+  // Opt-in (default false, Network Information API is Chromium-only): reduces requested
+  // bitrate for compressed formats on a Save-Data/2G-class connection.
+  adaptBitrateToNetwork?: boolean;
+}
+
+// Least-lossy first. Judgment calls, not measured against real encoder quality-per-byte curves.
+const QUALITY_RANK = ["flac", "wav", "opus", "aac", "ogg", "webm", "mp3"];
+// Smallest-transfer first.
+const BANDWIDTH_RANK = ["opus", "aac", "webm", "ogg", "mp3", "wav", "flac"];
+
+export function selectFormat(
+  output: { formats: string[]; default: string },
+  options: Pick<SpeechServerFormatOptions, "preferredFormat" | "strategy">,
+  canPlay: CanPlayType
+): string {
+  const isPlayable = (format: string): boolean => canPlay(mimeTypeForFormat(format)) !== "";
+  const playable = output.formats.filter(isPlayable);
+
+  if (options.preferredFormat && playable.includes(options.preferredFormat)) {
+    return options.preferredFormat;
+  }
+
+  const knownRank = options.strategy === "bandwidth" ? BANDWIDTH_RANK : QUALITY_RANK;
+  // Playable formats outside the known rank tables are still eligible, just ordered last.
+  const rank = [...knownRank, ...playable.filter(format => !knownRank.includes(format))];
+  for (const format of rank) {
+    if (playable.includes(format)) {
+      return format;
+    }
+  }
+
+  // Nothing playable — fall back to the server's default and let onerror surface the failure.
+  return output.default;
+}
+
+export interface NetworkInfo {
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+const LOSSLESS_FORMATS = new Set(["wav", "flac"]);
+
+// Unmeasured, conservative defaults; a format with no entry here just gets no adaptation.
+const REDUCED_BITRATE: Record<string, number> = {
+  mp3: 48000,
+  opus: 24000,
+  aac: 48000,
+  ogg: 48000,
+  webm: 32000
+};
+
+export function selectBitrate(
+  format: string,
+  adaptBitrateToNetwork: boolean,
+  network: NetworkInfo | undefined
+): number | undefined {
+  if (LOSSLESS_FORMATS.has(format) || !adaptBitrateToNetwork || !network) {
+    return undefined;
+  }
+  const isConstrained = network.saveData === true || /2g/.test(network.effectiveType ?? "");
+  return isConstrained ? REDUCED_BITRATE[format] : undefined;
+}

--- a/src/SpeechServer/speechServerEngine.ts
+++ b/src/SpeechServer/speechServerEngine.ts
@@ -4,16 +4,41 @@ import { ReadiumSpeechUtterance } from "../utterance";
 import { ReadiumSpeechVoice } from "../voices/types";
 import { mapServerVoice } from "./speechServerVoiceMapping";
 import { SpeechServerError, toSpeechServerError } from "./errors";
-import { SpeechServerSynthesizeBoundaryResponse, SpeechServerTimingMark, SpeechServerVoice } from "./types";
+import { chunkPlainText, chunkSsmlText, TextChunk } from "./chunkText";
+import { CanPlayType, mimeTypeForFormat, selectBitrate, selectFormat, SpeechServerFormatOptions } from "./selectFormat";
+import {
+  SpeechServerServiceInfo,
+  SpeechServerSynthesizeBoundaryResponse,
+  SpeechServerTimingMark,
+  SpeechServerVoice
+} from "./types";
+
+// navigator.connection (the Network Information API) isn't in the default lib.dom types and is
+// Chromium-only — this narrow local shape avoids reaching for `any` to read it.
+interface NavigatorConnection {
+  connection?: { saveData?: boolean; effectiveType?: string };
+}
+
+export interface SpeechServerEndpoints {
+  voices: string;
+  synthesize: string;
+  service: string;
+}
 
 export interface SpeechServerEngineOptions {
-  baseUrl: string;
+  endpoints: SpeechServerEndpoints;
   fetch?: typeof fetch;
   // Utterances to keep pre-fetched ahead of playback (buffer depth, not concurrency — requests are chained one at a time).
   prefetchWindow?: number;
   // Combined character count to have buffered before declaring "ready", so playback doesn't
   // outrun the buffer right after the first utterance.
   readyBufferChars?: number;
+  // Over-long utterance text: split into multiple /synthesize requests ("split", default), or
+  // fail fast with a SpeechServerError 413 payload_too_large ("error").
+  overLengthText?: "split" | "error";
+  // Output format/bitrate selection. Omit entirely to keep today's behavior (server's
+  // advertised default format, no bitrate sent). See SpeechServerFormatOptions for fields.
+  format?: SpeechServerFormatOptions;
 }
 
 const DEFAULT_PREFETCH_WINDOW = 3;
@@ -21,10 +46,20 @@ const DEFAULT_PREFETCH_WINDOW = 3;
 // how much buffer is needed to outlast a typical synth request, not tuned against real latency.
 const DEFAULT_READY_BUFFER_CHARS = 400;
 
-interface SynthesizeResult {
+interface SynthesizedChunk {
   audioUrl: string;
   format: string;
   boundaries: SpeechServerTimingMark[] | null;
+  // Character offset of this chunk's text within the original (unchunked) utterance text —
+  // added to each boundary mark's charIndex so events stay relative to the whole utterance.
+  textOffset: number;
+}
+
+// One utterance's synthesis result, as one or more sequential chunks (see synthesize()).
+type SynthesizeResult = SynthesizedChunk[];
+
+function revokeChunkUrls(chunks: SynthesizeResult): void {
+  chunks.forEach(chunk => URL.revokeObjectURL(chunk.audioUrl));
 }
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
@@ -34,18 +69,6 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
     bytes[i] = binary.charCodeAt(i);
   }
   return bytes.buffer;
-}
-
-function mimeTypeForFormat(format: string): string {
-  switch (format) {
-    case "mp3":
-      return "audio/mpeg";
-    case "opus":
-      return "audio/ogg";
-    case "wav":
-    default:
-      return "audio/wav";
-  }
 }
 
 // <audio>.playbackRate distorts or silently clamps outside ~0.25-4 in most engines.
@@ -68,11 +91,13 @@ function toErrorDetail(error: unknown): Record<string, unknown> {
 }
 
 export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
-  private baseUrl: string;
+  private endpoints: SpeechServerEndpoints;
   private fetchImpl: typeof fetch;
 
   private currentVoice: ReadiumSpeechVoice | null = null;
   private voices: ReadiumSpeechVoice[] = [];
+  private serviceInfo: SpeechServerServiceInfo | null = null;
+  private serviceInfoPromise: Promise<SpeechServerServiceInfo> | null = null;
   private currentUtterances: ReadiumSpeechUtterance[] = [];
   private currentUtteranceIndex: number = 0;
   private playbackState: ReadiumSpeechPlaybackState = "idle";
@@ -85,24 +110,33 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
   // Rolling buffer of upcoming utterances' audio, fetched one at a time via prefetchChainTail.
   private readonly prefetchWindow: number;
   private readonly readyBufferChars: number;
+  private readonly overLengthText: "split" | "error";
+  private readonly formatOptions: SpeechServerFormatOptions;
+  private readonly canPlayType: CanPlayType;
   private prefetchCache: Map<number, Promise<SynthesizeResult>> = new Map();
   private prefetchChainTail: Promise<void> = Promise.resolve();
 
   private audio: HTMLAudioElement | null = null;
-  private audioObjectUrl: string | null = null;
   private boundaryMarks: SpeechServerTimingMark[] = [];
   private nextBoundaryIndex: number = 0;
   private onTimeUpdate = (): void => this.checkBoundaries();
+
+  // The utterance chunk sequence currently playing/paused, and which of its chunks is live.
+  private currentChunks: SynthesizeResult = [];
+  private currentChunkIndex: number = 0;
 
   private rate: number = 1.0;
   private pitch: number = 1.0;
   private volume: number = 1.0;
 
   constructor(options: SpeechServerEngineOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.endpoints = options.endpoints;
     this.fetchImpl = options.fetch ?? fetch.bind(globalThis);
     this.prefetchWindow = options.prefetchWindow ?? DEFAULT_PREFETCH_WINDOW;
     this.readyBufferChars = options.readyBufferChars ?? DEFAULT_READY_BUFFER_CHARS;
+    this.overLengthText = options.overLengthText ?? "split";
+    this.formatOptions = options.format ?? {};
+    this.canPlayType = typeof Audio !== "undefined" ? (mime: string) => new Audio().canPlayType(mime) : () => "";
   }
 
   // Lets a provider that already fetched /voices seed this engine without a second request.
@@ -187,13 +221,37 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       return this.voices;
     }
 
-    const response = await this.fetchImpl(`${this.baseUrl}/voices`);
+    const response = await this.fetchImpl(this.endpoints.voices);
     if (!response.ok) {
       throw await toSpeechServerError(response);
     }
     const serverVoices: SpeechServerVoice[] = await response.json();
     this.voices = serverVoices.map(mapServerVoice);
     return this.voices;
+  }
+
+  // Cached after the first successful fetch; a failed fetch isn't cached, so the next
+  // synthesize() call retries rather than being stuck on a transient network error.
+  private async getServiceInfo(): Promise<SpeechServerServiceInfo> {
+    if (this.serviceInfo) {
+      return this.serviceInfo;
+    }
+    if (!this.serviceInfoPromise) {
+      this.serviceInfoPromise = this.fetchServiceInfo().catch(error => {
+        this.serviceInfoPromise = null;
+        throw error;
+      });
+    }
+    this.serviceInfo = await this.serviceInfoPromise;
+    return this.serviceInfo;
+  }
+
+  private async fetchServiceInfo(): Promise<SpeechServerServiceInfo> {
+    const response = await this.fetchImpl(this.endpoints.service);
+    if (!response.ok) {
+      throw await toSpeechServerError(response);
+    }
+    return response.json();
   }
 
   setSpeakInContentLanguage(enabled: boolean): void {
@@ -229,14 +287,14 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     const index = this.currentUtteranceIndex;
 
     try {
-      const { audioUrl, format, boundaries } = await this.resolveSynthesis(index);
+      const chunks = await this.resolveSynthesis(index);
 
       if (generation !== this.speakGeneration) {
-        URL.revokeObjectURL(audioUrl);
+        revokeChunkUrls(chunks);
         return;
       }
 
-      this.playAudio(audioUrl, format, boundaries, generation);
+      this.playChunks(chunks, generation);
       this.fillPrefetchWindow(index);
     } catch (error) {
       if (generation !== this.speakGeneration) {
@@ -283,10 +341,10 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     promise.catch(() => {}); // avoid an unhandled rejection if nothing ever consumes this
   }
 
-  // Revokes every buffered prefetch's blob URL once settled, and empties the cache.
+  // Revokes every buffered prefetch's blob URLs once settled, and empties the cache.
   private clearPrefetchCache(): void {
     for (const promise of this.prefetchCache.values()) {
-      promise.then(({ audioUrl }) => URL.revokeObjectURL(audioUrl)).catch(() => {});
+      promise.then(revokeChunkUrls).catch(() => {});
     }
     this.prefetchCache.clear();
   }
@@ -295,24 +353,69 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     const content = this.currentUtterances[index];
     const useSSML = !content.plain && !!content.ssml;
     const language = this.speakInContentLanguage ? content.language : undefined;
+    const text = utteranceText(content) ?? "";
 
     // ReadiumSpeechUtterance has no prev/next fields of its own — read neighbors from the queue.
     const prevUtterance = utteranceText(this.currentUtterances[index - 1]);
     const nextUtterance = utteranceText(this.currentUtterances[index + 1]);
 
-    const response = await this.fetchImpl(`${this.baseUrl}/synthesize`, {
+    const serviceInfo = await this.getServiceInfo();
+    const format = selectFormat(serviceInfo.output, this.formatOptions, this.canPlayType);
+    const connection = (navigator as unknown as NavigatorConnection).connection;
+    const bitrate = selectBitrate(format, this.formatOptions.adaptBitrateToNetwork ?? false, connection);
+
+    if (text.length <= serviceInfo.limits.maxTextLength) {
+      const chunk = await this.synthesizeChunk(content, text, 0, useSSML, language, prevUtterance, nextUtterance, format, bitrate);
+      return [chunk];
+    }
+
+    if (this.overLengthText === "error") {
+      throw new SpeechServerError(
+        `Text exceeds this server's maximum length of ${serviceInfo.limits.maxTextLength} characters`,
+        {
+          status: 413,
+          type: "https://readium.org/speech-server/error#payload_too_large",
+          title: "Payload Too Large"
+        }
+      );
+    }
+
+    const textChunks: TextChunk[] = useSSML
+      ? chunkSsmlText(text, serviceInfo.limits.maxTextLength)
+      : chunkPlainText(text, serviceInfo.limits.maxTextLength);
+    const chunks: SynthesizedChunk[] = [];
+    for (let i = 0; i < textChunks.length; i++) {
+      const prevText = i === 0 ? prevUtterance : textChunks[i - 1].text;
+      const nextText = i === textChunks.length - 1 ? nextUtterance : textChunks[i + 1].text;
+      chunks.push(await this.synthesizeChunk(content, textChunks[i].text, textChunks[i].offset, useSSML, language, prevText, nextText, format, bitrate));
+    }
+    return chunks;
+  }
+
+  private async synthesizeChunk(
+    content: ReadiumSpeechUtterance,
+    text: string,
+    textOffset: number,
+    useSSML: boolean,
+    language: string | undefined,
+    prevText: string | undefined,
+    nextText: string | undefined,
+    format: string,
+    bitrate: number | undefined
+  ): Promise<SynthesizedChunk> {
+    const response = await this.fetchImpl(this.endpoints.synthesize, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         id: content.id,
-        text: utteranceText(content) ?? "",
+        text,
         ssml: useSSML,
         language,
         voice: this.currentVoice?.identifier ?? this.currentVoice?.name,
-        prev_utterance: prevUtterance,
-        next_utterance: nextUtterance,
+        prev_utterance: prevText,
+        next_utterance: nextText,
         boundary: true,
-        output: { speed: this.rate, pitch: this.pitch }
+        output: { format, bitrate, speed: this.rate, pitch: this.pitch }
       })
     });
 
@@ -325,14 +428,22 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     const blob = new Blob([buffer], { type: mimeTypeForFormat(json.format) });
     const audioUrl = URL.createObjectURL(blob);
 
-    return { audioUrl, format: json.format, boundaries: json.boundaries };
+    return { audioUrl, format: json.format, boundaries: json.boundaries, textOffset };
   }
 
-  private playAudio(url: string, _format: string, boundaries: SpeechServerTimingMark[] | null, generation: number): void {
-    const audio = new Audio(url);
+  private playChunks(chunks: SynthesizeResult, generation: number): void {
+    this.currentChunks = chunks;
+    this.currentChunkIndex = 0;
+    this.setState("playing");
+    this.emitEvent({ type: "start" });
+    this.playChunk(0, generation);
+  }
+
+  private playChunk(chunkIndex: number, generation: number): void {
+    const chunk = this.currentChunks[chunkIndex];
+    const audio = new Audio(chunk.audioUrl);
     this.audio = audio;
-    this.audioObjectUrl = url;
-    this.boundaryMarks = boundaries ?? [];
+    this.boundaryMarks = chunk.boundaries ?? [];
     this.nextBoundaryIndex = 0;
 
     audio.volume = Math.max(0, Math.min(1, this.volume));
@@ -347,6 +458,13 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
         return;
       }
       this.checkBoundaries();
+
+      if (chunkIndex < this.currentChunks.length - 1) {
+        this.currentChunkIndex = chunkIndex + 1;
+        this.playChunk(chunkIndex + 1, generation);
+        return;
+      }
+
       if (this.currentUtteranceIndex >= this.currentUtterances.length - 1) {
         this.setState("idle");
       }
@@ -361,8 +479,6 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       this.emitEvent({ type: "error", detail: { message: "Audio playback failed" } });
     };
 
-    this.setState("playing");
-    this.emitEvent({ type: "start" });
     void audio.play();
   }
 
@@ -371,6 +487,8 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     if (!audio) {
       return;
     }
+    const chunk = this.currentChunks[this.currentChunkIndex];
+    const charOffset = chunk?.textOffset ?? 0;
     while (
       this.nextBoundaryIndex < this.boundaryMarks.length &&
       audio.currentTime >= this.boundaryMarks[this.nextBoundaryIndex].elapsedTime
@@ -380,7 +498,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
         type: "boundary",
         detail: {
           name: mark.name,
-          charIndex: mark.charIndex,
+          charIndex: mark.charIndex + charOffset,
           charLength: mark.charLength,
           elapsedTime: mark.elapsedTime
         }
@@ -396,10 +514,11 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       this.audio.src = "";
       this.audio = null;
     }
-    if (this.audioObjectUrl) {
-      URL.revokeObjectURL(this.audioObjectUrl);
-      this.audioObjectUrl = null;
-    }
+    // Revokes every chunk of the current utterance, played or not — URL.revokeObjectURL is a
+    // safe no-op on an already-revoked URL, so this also covers chunks consumed via onended.
+    revokeChunkUrls(this.currentChunks);
+    this.currentChunks = [];
+    this.currentChunkIndex = 0;
     this.boundaryMarks = [];
     this.nextBoundaryIndex = 0;
   }

--- a/src/SpeechServer/speechServerEngine.ts
+++ b/src/SpeechServer/speechServerEngine.ts
@@ -5,7 +5,7 @@ import { ReadiumSpeechVoice } from "../voices/types";
 import { mapServerVoice } from "./speechServerVoiceMapping";
 import { SpeechServerError, toSpeechServerError } from "./errors";
 import { chunkPlainText, chunkSsmlText, TextChunk } from "./chunkText";
-import { CanPlayType, mimeTypeForFormat, selectBitrate, selectFormat, SpeechServerFormatOptions } from "./selectFormat";
+import { CanPlayType, selectBitrate, selectFormat, SpeechServerFormatOptions } from "./selectFormat";
 import {
   SpeechServerServiceInfo,
   SpeechServerSynthesizeBoundaryResponse,
@@ -47,7 +47,7 @@ const DEFAULT_PREFETCH_WINDOW = 3;
 const DEFAULT_READY_BUFFER_CHARS = 400;
 
 interface SynthesizedChunk {
-  audioUrl: string;
+  audioBuffer: AudioBuffer;
   format: string;
   boundaries: SpeechServerTimingMark[] | null;
   // Character offset of this chunk's text within the original (unchunked) utterance text —
@@ -55,11 +55,18 @@ interface SynthesizedChunk {
   textOffset: number;
 }
 
-// One utterance's synthesis result, as one or more sequential chunks (see synthesize()).
-type SynthesizeResult = SynthesizedChunk[];
+// One promise per chunk of an utterance, chained internally one request at a time.
+type ChunkStream = Promise<SynthesizedChunk>[];
 
-function revokeChunkUrls(chunks: SynthesizeResult): void {
-  chunks.forEach(chunk => URL.revokeObjectURL(chunk.audioUrl));
+// One chunk's node on the AudioContext timeline, in schedule order.
+interface ScheduledChunk {
+  chunk: SynthesizedChunk;
+  startTime: number;
+  node: AudioBufferSourceNode;
+  nextBoundaryIndex: number;
+  // The rate this node was actually scheduled with — a later setRate() doesn't retroactively
+  // alter it, so boundary math must use this rather than a freshly-read this.rate.
+  rate: number;
 }
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
@@ -113,17 +120,13 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
   private readonly overLengthText: "split" | "error";
   private readonly formatOptions: SpeechServerFormatOptions;
   private readonly canPlayType: CanPlayType;
-  private prefetchCache: Map<number, Promise<SynthesizeResult>> = new Map();
+  private prefetchCache: Map<number, Promise<ChunkStream>> = new Map();
   private prefetchChainTail: Promise<void> = Promise.resolve();
 
-  private audio: HTMLAudioElement | null = null;
-  private boundaryMarks: SpeechServerTimingMark[] = [];
-  private nextBoundaryIndex: number = 0;
-  private onTimeUpdate = (): void => this.checkBoundaries();
-
-  // The utterance chunk sequence currently playing/paused, and which of its chunks is live.
-  private currentChunks: SynthesizeResult = [];
-  private currentChunkIndex: number = 0;
+  private audioContext: AudioContext | null = null;
+  private masterGain: GainNode | null = null;
+  private scheduledChunks: ScheduledChunk[] = [];
+  private boundaryRafHandle: number | null = null;
 
   private rate: number = 1.0;
   private pitch: number = 1.0;
@@ -152,18 +155,19 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     void this.bufferUntilReady(++this.loadGeneration);
   }
 
-  // Buffers enough leading utterances to cover readyBufferChars before declaring "ready",
-  // so playback doesn't catch up to an empty prefetch cache right after the first utterance.
+  // Buffers enough leading utterances to cover readyBufferChars before declaring "ready", so
+  // playback doesn't catch up to an empty prefetch cache right after the first utterance.
   private async bufferUntilReady(generation: number): Promise<void> {
     // Bounded by prefetchWindow too — the initial buffer is just the front of that same
     // lookahead, not a second, larger one.
     const targetIndex = Math.min(this.indexCoveringChars(this.readyBufferChars), this.prefetchWindow);
-    const pending: Promise<SynthesizeResult>[] = [];
+    const pending: Promise<SynthesizedChunk>[] = [];
     for (let index = 0; index <= targetIndex; index++) {
       this.queuePrefetch(index);
       const cached = this.prefetchCache.get(index);
       if (cached) {
-        pending.push(cached);
+        // Only the first chunk needs to be ready for playback to start.
+        pending.push(cached.then(chunkStream => chunkStream[0]));
       }
     }
 
@@ -173,7 +177,9 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       // A failed prefetch still unblocks "ready" — the actual error surfaces when speak() retries it.
     }
 
-    if (generation !== this.loadGeneration) {
+    // speak() may have already moved playback state forward while this was buffering — don't
+    // stomp that back to "ready".
+    if (generation !== this.loadGeneration || this.playbackState !== "loading") {
       return;
     }
     this.setState("ready");
@@ -287,14 +293,13 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     const index = this.currentUtteranceIndex;
 
     try {
-      const chunks = await this.resolveSynthesis(index);
+      const chunkStream = await this.resolveSynthesisStream(index);
 
       if (generation !== this.speakGeneration) {
-        revokeChunkUrls(chunks);
         return;
       }
 
-      this.playChunks(chunks, generation);
+      await this.scheduleChunksStreaming(chunkStream, generation);
       this.fillPrefetchWindow(index);
     } catch (error) {
       if (generation !== this.speakGeneration) {
@@ -310,7 +315,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   // Reuses a cached prefetch if one exists; a fresh fetch bypasses the prefetch chain
   // (shouldn't wait behind buffered-ahead requests), and a failed prefetch retries fresh.
-  private async resolveSynthesis(index: number): Promise<SynthesizeResult> {
+  private async resolveSynthesisStream(index: number): Promise<ChunkStream> {
     const cached = this.prefetchCache.get(index);
     if (cached) {
       this.prefetchCache.delete(index);
@@ -320,7 +325,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
         // fall through to a fresh attempt
       }
     }
-    return this.synthesize(index);
+    return this.synthesizeStream(index);
   }
 
   // Chains up to `prefetchWindow` upcoming indices onto prefetchChainTail, one at a time.
@@ -335,21 +340,23 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     if (this.prefetchCache.has(index)) {
       return;
     }
-    const promise = this.prefetchChainTail.then(() => this.synthesize(index));
-    this.prefetchCache.set(index, promise);
-    this.prefetchChainTail = promise.then(() => undefined, () => undefined);
-    promise.catch(() => {}); // avoid an unhandled rejection if nothing ever consumes this
+    const streamPromise = this.prefetchChainTail.then(() => this.synthesizeStream(index));
+    this.prefetchCache.set(index, streamPromise);
+    // The next queued utterance's own first request shouldn't jump ahead of this one's last
+    // chunk — so the chain only advances once every chunk of this stream has settled.
+    this.prefetchChainTail = streamPromise.then(chunkStream => Promise.all(chunkStream)).then(
+      () => undefined,
+      () => undefined
+    );
+    streamPromise.catch(() => {}); // avoid an unhandled rejection if nothing ever consumes this
+    streamPromise.then(chunkStream => chunkStream.forEach(p => p.catch(() => {}))).catch(() => {});
   }
 
-  // Revokes every buffered prefetch's blob URLs once settled, and empties the cache.
   private clearPrefetchCache(): void {
-    for (const promise of this.prefetchCache.values()) {
-      promise.then(revokeChunkUrls).catch(() => {});
-    }
     this.prefetchCache.clear();
   }
 
-  private async synthesize(index: number): Promise<SynthesizeResult> {
+  private async synthesizeStream(index: number): Promise<ChunkStream> {
     const content = this.currentUtterances[index];
     const useSSML = !content.plain && !!content.ssml;
     const language = this.speakInContentLanguage ? content.language : undefined;
@@ -365,8 +372,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     const bitrate = selectBitrate(format, this.formatOptions.adaptBitrateToNetwork ?? false, connection);
 
     if (text.length <= serviceInfo.limits.maxTextLength) {
-      const chunk = await this.synthesizeChunk(content, text, 0, useSSML, language, prevUtterance, nextUtterance, format, bitrate);
-      return [chunk];
+      return [this.synthesizeChunk(content, text, 0, useSSML, language, prevUtterance, nextUtterance, format, bitrate)];
     }
 
     if (this.overLengthText === "error") {
@@ -380,16 +386,25 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       );
     }
 
-    const textChunks: TextChunk[] = useSSML
-      ? chunkSsmlText(text, serviceInfo.limits.maxTextLength)
-      : chunkPlainText(text, serviceInfo.limits.maxTextLength);
-    const chunks: SynthesizedChunk[] = [];
+    // readyBufferChars is the assumed safe margin for one synth request to finish before
+    // playback catches up to it, so each split chunk is capped at that size, not maxTextLength.
+    const chunkMaxLength = Math.min(serviceInfo.limits.maxTextLength, this.readyBufferChars);
+    const textChunks = useSSML ? chunkSsmlText(text, chunkMaxLength) : chunkPlainText(text, chunkMaxLength);
+
+    const chunkStream: ChunkStream = [];
+    let chain: Promise<SynthesizedChunk> | Promise<void> = Promise.resolve();
     for (let i = 0; i < textChunks.length; i++) {
       const prevText = i === 0 ? prevUtterance : textChunks[i - 1].text;
       const nextText = i === textChunks.length - 1 ? nextUtterance : textChunks[i + 1].text;
-      chunks.push(await this.synthesizeChunk(content, textChunks[i].text, textChunks[i].offset, useSSML, language, prevText, nextText, format, bitrate));
+      const textChunk = textChunks[i];
+      // A rejected chain skips later .then() bodies entirely, so one failed chunk stops the rest.
+      const chunkPromise: Promise<SynthesizedChunk> = chain.then(() =>
+        this.synthesizeChunk(content, textChunk.text, textChunk.offset, useSSML, language, prevText, nextText, format, bitrate)
+      );
+      chunkStream.push(chunkPromise);
+      chain = chunkPromise;
     }
-    return chunks;
+    return chunkStream;
   }
 
   private async synthesizeChunk(
@@ -425,115 +440,178 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
     const json: SpeechServerSynthesizeBoundaryResponse = await response.json();
     const buffer = base64ToArrayBuffer(json.audio);
-    const blob = new Blob([buffer], { type: mimeTypeForFormat(json.format) });
-    const audioUrl = URL.createObjectURL(blob);
+    let audioBuffer: AudioBuffer;
+    try {
+      audioBuffer = await this.ensureAudioContext().decodeAudioData(buffer);
+    } catch {
+      throw new Error("Audio playback failed");
+    }
 
-    return { audioUrl, format: json.format, boundaries: json.boundaries, textOffset };
+    return { audioBuffer, format: json.format, boundaries: json.boundaries, textOffset };
   }
 
-  private playChunks(chunks: SynthesizeResult, generation: number): void {
-    this.currentChunks = chunks;
-    this.currentChunkIndex = 0;
-    this.setState("playing");
-    this.emitEvent({ type: "start" });
-    this.playChunk(0, generation);
+  // May run ahead of a user gesture (called from synthesizeChunk during prefetch), but only
+  // constructs the context here — actual playback still only ever starts from speak().
+  private ensureAudioContext(): AudioContext {
+    if (!this.audioContext) {
+      this.audioContext = new AudioContext();
+      this.masterGain = this.audioContext.createGain();
+      this.masterGain.gain.value = this.volume;
+      this.masterGain.connect(this.audioContext.destination);
+    }
+    if (this.audioContext.state === "suspended") {
+      void this.audioContext.resume();
+    }
+    return this.audioContext;
   }
 
-  private playChunk(chunkIndex: number, generation: number): void {
-    const chunk = this.currentChunks[chunkIndex];
-    const audio = new Audio(chunk.audioUrl);
-    this.audio = audio;
-    this.boundaryMarks = chunk.boundaries ?? [];
-    this.nextBoundaryIndex = 0;
+  // Schedules chunks onto one continuous AudioContext timeline as they resolve.
+  private async scheduleChunksStreaming(chunkStream: ChunkStream, generation: number): Promise<void> {
+    // Left uncaught: the caller's own catch handles a first-chunk failure as a playback error.
+    const first = await chunkStream[0];
+    if (generation !== this.speakGeneration) {
+      return;
+    }
 
-    audio.volume = Math.max(0, Math.min(1, this.volume));
+    const ctx = this.ensureAudioContext();
+    const gain = this.masterGain!;
     // Only fake the rate locally when the server won't honor output.speed itself, else it'd double up.
     const speedHonoredByServer = this.currentVoice?.controls?.speed === true;
-    audio.playbackRate = speedHonoredByServer ? 1 : clampPlaybackRate(this.rate);
+    const rate = speedHonoredByServer ? 1 : clampPlaybackRate(this.rate);
 
-    audio.addEventListener("timeupdate", this.onTimeUpdate);
+    this.scheduledChunks = [];
+    this.setState("playing");
+    this.emitEvent({ type: "start" });
 
-    audio.onended = () => {
+    let t = ctx.currentTime;
+    // Only the most recently scheduled node's onended should end the utterance.
+    let lastNode: AudioBufferSourceNode | null = null;
+
+    const scheduleOne = (chunk: SynthesizedChunk): void => {
+      const node = ctx.createBufferSource();
+      node.buffer = chunk.audioBuffer;
+      node.playbackRate.value = rate;
+      node.connect(gain);
+      node.start(t);
+      if (lastNode) {
+        lastNode.onended = null;
+      }
+      node.onended = () => this.handleUtteranceEnded(generation);
+      lastNode = node;
+      this.scheduledChunks.push({ chunk, startTime: t, node, nextBoundaryIndex: 0, rate });
+      // Duration scales with playbackRate: a node played at 2x finishes in half the
+      // wall-clock time, so the next node's start time must account for that.
+      t += chunk.audioBuffer.duration / rate;
+    };
+
+    scheduleOne(first);
+    this.startBoundaryPolling(generation);
+
+    for (let i = 1; i < chunkStream.length; i++) {
+      let chunk: SynthesizedChunk;
+      try {
+        chunk = await chunkStream[i];
+      } catch (error) {
+        // A later chunk failing doesn't retroactively silence what's already scheduled — it
+        // just means the utterance ends once the already-scheduled audio finishes playing.
+        if (generation === this.speakGeneration) {
+          this.emitEvent({ type: "error", detail: toErrorDetail(error) });
+        }
+        return;
+      }
+      if (generation !== this.speakGeneration) {
+        return;
+      }
+      scheduleOne(chunk);
+    }
+  }
+
+  private handleUtteranceEnded(generation: number): void {
+    if (generation !== this.speakGeneration) {
+      return;
+    }
+    // Flush any boundary whose mark falls inside the last polling tick before ended fired.
+    this.checkBoundaries();
+    this.stopBoundaryPolling();
+
+    if (this.currentUtteranceIndex >= this.currentUtterances.length - 1) {
+      this.setState("idle");
+    }
+    this.emitEvent({ type: "end" });
+  }
+
+  private startBoundaryPolling(generation: number): void {
+    const tick = (): void => {
       if (generation !== this.speakGeneration) {
         return;
       }
       this.checkBoundaries();
-
-      if (chunkIndex < this.currentChunks.length - 1) {
-        this.currentChunkIndex = chunkIndex + 1;
-        this.playChunk(chunkIndex + 1, generation);
-        return;
-      }
-
-      if (this.currentUtteranceIndex >= this.currentUtterances.length - 1) {
-        this.setState("idle");
-      }
-      this.emitEvent({ type: "end" });
+      this.boundaryRafHandle = requestAnimationFrame(tick);
     };
+    this.boundaryRafHandle = requestAnimationFrame(tick);
+  }
 
-    audio.onerror = () => {
-      if (generation !== this.speakGeneration) {
-        return;
-      }
-      this.setState("idle");
-      this.emitEvent({ type: "error", detail: { message: "Audio playback failed" } });
-    };
-
-    void audio.play();
+  private stopBoundaryPolling(): void {
+    if (this.boundaryRafHandle !== null) {
+      cancelAnimationFrame(this.boundaryRafHandle);
+      this.boundaryRafHandle = null;
+    }
   }
 
   private checkBoundaries(): void {
-    const audio = this.audio;
-    if (!audio) {
+    if (!this.audioContext) {
       return;
     }
-    const chunk = this.currentChunks[this.currentChunkIndex];
-    const charOffset = chunk?.textOffset ?? 0;
-    while (
-      this.nextBoundaryIndex < this.boundaryMarks.length &&
-      audio.currentTime >= this.boundaryMarks[this.nextBoundaryIndex].elapsedTime
-    ) {
-      const mark = this.boundaryMarks[this.nextBoundaryIndex];
-      this.emitEvent({
-        type: "boundary",
-        detail: {
-          name: mark.name,
-          charIndex: mark.charIndex + charOffset,
-          charLength: mark.charLength,
-          elapsedTime: mark.elapsedTime
-        }
-      });
-      this.nextBoundaryIndex++;
+    const now = this.audioContext.currentTime;
+
+    for (const entry of this.scheduledChunks) {
+      const marks = entry.chunk.boundaries ?? [];
+      while (
+        entry.nextBoundaryIndex < marks.length &&
+        now >= entry.startTime + marks[entry.nextBoundaryIndex].elapsedTime / entry.rate
+      ) {
+        const mark = marks[entry.nextBoundaryIndex];
+        this.emitEvent({
+          type: "boundary",
+          detail: {
+            name: mark.name,
+            charIndex: mark.charIndex + entry.chunk.textOffset,
+            charLength: mark.charLength,
+            elapsedTime: mark.elapsedTime
+          }
+        });
+        entry.nextBoundaryIndex++;
+      }
     }
   }
 
   private stopAudio(): void {
-    if (this.audio) {
-      this.audio.pause();
-      this.audio.removeEventListener("timeupdate", this.onTimeUpdate);
-      this.audio.src = "";
-      this.audio = null;
+    this.stopBoundaryPolling();
+    for (const entry of this.scheduledChunks) {
+      entry.node.onended = null; // avoid a stray handleUtteranceEnded() from our own stop()
+      try {
+        entry.node.stop();
+      } catch {
+        // stop() throws if the node already ended or was never started — fine to ignore
+      }
+      entry.node.disconnect();
     }
-    // Revokes every chunk of the current utterance, played or not — URL.revokeObjectURL is a
-    // safe no-op on an already-revoked URL, so this also covers chunks consumed via onended.
-    revokeChunkUrls(this.currentChunks);
-    this.currentChunks = [];
-    this.currentChunkIndex = 0;
-    this.boundaryMarks = [];
-    this.nextBoundaryIndex = 0;
+    this.scheduledChunks = [];
   }
 
   pause(): void {
-    if (this.playbackState === "playing" && this.audio) {
-      this.audio.pause();
+    if (this.playbackState === "playing" && this.audioContext) {
+      void this.audioContext.suspend();
+      this.stopBoundaryPolling();
       this.setState("paused");
       this.emitEvent({ type: "pause" });
     }
   }
 
   resume(): void {
-    if (this.playbackState === "paused" && this.audio) {
-      void this.audio.play();
+    if (this.playbackState === "paused" && this.audioContext) {
+      void this.audioContext.resume();
+      this.startBoundaryPolling(this.speakGeneration);
       this.setState("playing");
       this.emitEvent({ type: "resume" });
     }
@@ -569,8 +647,8 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   setVolume(volume: number): void {
     this.volume = Math.max(0, Math.min(1, volume));
-    if (this.audio) {
-      this.audio.volume = this.volume;
+    if (this.masterGain) {
+      this.masterGain.gain.value = this.volume;
     }
   }
 
@@ -650,6 +728,9 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   async destroy(): Promise<void> {
     this.stop();
+    await this.audioContext?.close();
+    this.audioContext = null;
+    this.masterGain = null;
     this.eventListeners.clear();
     this.currentUtterances = [];
     this.currentVoice = null;

--- a/src/SpeechServer/speechServerEngine.ts
+++ b/src/SpeechServer/speechServerEngine.ts
@@ -3,12 +3,22 @@ import { ReadiumSpeechPlaybackEvent, ReadiumSpeechPlaybackState } from "../navig
 import { ReadiumSpeechUtterance } from "../utterance";
 import { ReadiumSpeechVoice } from "../voices/types";
 import { mapServerVoice } from "./speechServerVoiceMapping";
-import { toSpeechServerError } from "./errors";
+import { SpeechServerError, toSpeechServerError } from "./errors";
 import { SpeechServerSynthesizeBoundaryResponse, SpeechServerTimingMark, SpeechServerVoice } from "./types";
 
 export interface SpeechServerEngineOptions {
   baseUrl: string;
   fetch?: typeof fetch;
+  // Utterances to keep pre-fetched ahead of playback (buffer depth, not concurrency — requests are chained one at a time).
+  prefetchWindow?: number;
+}
+
+const DEFAULT_PREFETCH_WINDOW = 3;
+
+interface SynthesizeResult {
+  audioUrl: string;
+  format: string;
+  boundaries: SpeechServerTimingMark[] | null;
 }
 
 function base64ToArrayBuffer(base64: string): ArrayBuffer {
@@ -32,10 +42,23 @@ function mimeTypeForFormat(format: string): string {
   }
 }
 
-// <audio>.playbackRate has no reliable browser-enforced range; most engines
-// distort or silently clamp outside ~0.25-4.
+// <audio>.playbackRate distorts or silently clamps outside ~0.25-4 in most engines.
 function clampPlaybackRate(rate: number): number {
   return Math.max(0.25, Math.min(4, rate));
+}
+
+function utteranceText(utterance: ReadiumSpeechUtterance | undefined): string | undefined {
+  return utterance?.plain ?? utterance?.ssml ?? undefined;
+}
+
+function toErrorDetail(error: unknown): Record<string, unknown> {
+  if (error instanceof SpeechServerError) {
+    return { message: error.message, status: error.status, type: error.type, title: error.title, instance: error.instance };
+  }
+  if (error instanceof Error) {
+    return { message: error.message };
+  }
+  return { message: String(error) };
 }
 
 export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
@@ -52,6 +75,11 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
   private speakInContentLanguage: boolean = false;
   private speakGeneration: number = 0;
 
+  // Rolling buffer of upcoming utterances' audio, fetched one at a time via prefetchChainTail.
+  private readonly prefetchWindow: number;
+  private prefetchCache: Map<number, Promise<SynthesizeResult>> = new Map();
+  private prefetchChainTail: Promise<void> = Promise.resolve();
+
   private audio: HTMLAudioElement | null = null;
   private audioObjectUrl: string | null = null;
   private boundaryMarks: SpeechServerTimingMark[] = [];
@@ -65,6 +93,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
   constructor(options: SpeechServerEngineOptions) {
     this.baseUrl = options.baseUrl.replace(/\/$/, "");
     this.fetchImpl = options.fetch ?? fetch.bind(globalThis);
+    this.prefetchWindow = options.prefetchWindow ?? DEFAULT_PREFETCH_WINDOW;
   }
 
   // Lets a provider that already fetched /voices seed this engine without a second request.
@@ -72,20 +101,18 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     this.voices = voices;
   }
 
-  // Queue Management
   loadUtterances(contents: ReadiumSpeechUtterance[]): void {
+    this.clearPrefetchCache();
     this.currentUtterances = contents;
     this.currentUtteranceIndex = 0;
     this.setState("ready");
     this.emitEvent({ type: "ready" });
   }
 
-  // Voice Configuration
   setVoice(voice: ReadiumSpeechVoice | string): void {
     if (typeof voice === "string") {
       const found = this.voices.find(v => v.identifier === voice || v.name === voice);
-      // Not in the cached list yet (e.g. a raw identifier set before getAvailableVoices())
-      // — the server accepts a raw identifier/originalName directly, so keep it usable.
+      // Not cached yet — the server accepts a raw identifier/originalName directly.
       this.currentVoice = found ?? {
         source: "server",
         label: voice,
@@ -97,6 +124,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     } else {
       this.currentVoice = voice;
     }
+    this.clearPrefetchCache();
   }
 
   getCurrentVoice(): ReadiumSpeechVoice | null {
@@ -119,13 +147,13 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   setSpeakInContentLanguage(enabled: boolean): void {
     this.speakInContentLanguage = enabled;
+    this.clearPrefetchCache();
   }
 
   getSpeakInContentLanguage(): boolean {
     return this.speakInContentLanguage;
   }
 
-  // Playback Control
   speak(utteranceIndex?: number): void {
     if (utteranceIndex !== undefined) {
       if (utteranceIndex < 0 || utteranceIndex >= this.currentUtterances.length) {
@@ -147,10 +175,10 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
   }
 
   private async synthesizeAndPlay(generation: number): Promise<void> {
-    const content = this.currentUtterances[this.currentUtteranceIndex];
+    const index = this.currentUtteranceIndex;
 
     try {
-      const { audioUrl, format, boundaries } = await this.synthesize(content);
+      const { audioUrl, format, boundaries } = await this.resolveSynthesis(index);
 
       if (generation !== this.speakGeneration) {
         URL.revokeObjectURL(audioUrl);
@@ -158,6 +186,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       }
 
       this.playAudio(audioUrl, format, boundaries, generation);
+      this.fillPrefetchWindow(index);
     } catch (error) {
       if (generation !== this.speakGeneration) {
         return;
@@ -165,28 +194,72 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       this.setState("idle");
       this.emitEvent({
         type: "error",
-        detail: error instanceof Error ? { message: error.message } : { message: String(error) }
+        detail: toErrorDetail(error)
       });
     }
   }
 
-  private async synthesize(content: ReadiumSpeechUtterance): Promise<{
-    audioUrl: string;
-    format: string;
-    boundaries: SpeechServerTimingMark[] | null;
-  }> {
+  // Reuses a cached prefetch if one exists; a fresh fetch bypasses the prefetch chain
+  // (shouldn't wait behind buffered-ahead requests), and a failed prefetch retries fresh.
+  private async resolveSynthesis(index: number): Promise<SynthesizeResult> {
+    const cached = this.prefetchCache.get(index);
+    if (cached) {
+      this.prefetchCache.delete(index);
+      try {
+        return await cached;
+      } catch {
+        // fall through to a fresh attempt
+      }
+    }
+    return this.synthesize(index);
+  }
+
+  // Chains up to `prefetchWindow` upcoming indices onto prefetchChainTail, one at a time.
+  private fillPrefetchWindow(afterIndex: number): void {
+    const end = Math.min(afterIndex + this.prefetchWindow, this.currentUtterances.length - 1);
+    for (let index = afterIndex + 1; index <= end; index++) {
+      this.queuePrefetch(index);
+    }
+  }
+
+  private queuePrefetch(index: number): void {
+    if (this.prefetchCache.has(index)) {
+      return;
+    }
+    const promise = this.prefetchChainTail.then(() => this.synthesize(index));
+    this.prefetchCache.set(index, promise);
+    this.prefetchChainTail = promise.then(() => undefined, () => undefined);
+    promise.catch(() => {}); // avoid an unhandled rejection if nothing ever consumes this
+  }
+
+  // Revokes every buffered prefetch's blob URL once settled, and empties the cache.
+  private clearPrefetchCache(): void {
+    for (const promise of this.prefetchCache.values()) {
+      promise.then(({ audioUrl }) => URL.revokeObjectURL(audioUrl)).catch(() => {});
+    }
+    this.prefetchCache.clear();
+  }
+
+  private async synthesize(index: number): Promise<SynthesizeResult> {
+    const content = this.currentUtterances[index];
     const useSSML = !content.plain && !!content.ssml;
     const language = this.speakInContentLanguage ? content.language : undefined;
+
+    // ReadiumSpeechUtterance has no prev/next fields of its own — read neighbors from the queue.
+    const prevUtterance = utteranceText(this.currentUtterances[index - 1]);
+    const nextUtterance = utteranceText(this.currentUtterances[index + 1]);
 
     const response = await this.fetchImpl(`${this.baseUrl}/synthesize`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         id: content.id,
-        text: content.plain ?? content.ssml ?? "",
+        text: utteranceText(content) ?? "",
         ssml: useSSML,
         language,
         voice: this.currentVoice?.identifier ?? this.currentVoice?.name,
+        prev_utterance: prevUtterance,
+        next_utterance: nextUtterance,
         boundary: true,
         output: { speed: this.rate, pitch: this.pitch }
       })
@@ -212,9 +285,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     this.nextBoundaryIndex = 0;
 
     audio.volume = Math.max(0, Math.min(1, this.volume));
-    // Only fake the rate on playback when the voice won't honor `output.speed` itself
-    // (true today for every PocketTTS voice) — otherwise a future provider that does
-    // apply server-side speed would get sped up twice.
+    // Only fake the rate locally when the server won't honor output.speed itself, else it'd double up.
     const speedHonoredByServer = this.currentVoice?.controls?.speed === true;
     audio.playbackRate = speedHonoredByServer ? 1 : clampPlaybackRate(this.rate);
 
@@ -301,14 +372,15 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
   stop(): void {
     this.speakGeneration++;
     this.stopAudio();
+    this.clearPrefetchCache();
     this.currentUtteranceIndex = 0;
     this.setState("idle");
     this.emitEvent({ type: "stop" });
   }
 
-  // Playback Parameters
   setRate(rate: number): void {
     this.rate = Math.max(0.1, Math.min(10, rate));
+    this.clearPrefetchCache();
   }
 
   getRate(): number {
@@ -317,6 +389,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   setPitch(pitch: number): void {
     this.pitch = Math.max(0, Math.min(2, pitch));
+    this.clearPrefetchCache();
   }
 
   getPitch(): number {
@@ -334,7 +407,6 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     return this.volume;
   }
 
-  // State
   getState(): ReadiumSpeechPlaybackState {
     return this.playbackState;
   }
@@ -362,7 +434,6 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     return this.currentUtterances.length;
   }
 
-  // Events
   on(event: ReadiumSpeechPlaybackEvent["type"], callback: (event: ReadiumSpeechPlaybackEvent) => void): () => void {
     if (!this.eventListeners.has(event)) {
       this.eventListeners.set(event, []);

--- a/src/SpeechServer/speechServerEngine.ts
+++ b/src/SpeechServer/speechServerEngine.ts
@@ -11,9 +11,15 @@ export interface SpeechServerEngineOptions {
   fetch?: typeof fetch;
   // Utterances to keep pre-fetched ahead of playback (buffer depth, not concurrency — requests are chained one at a time).
   prefetchWindow?: number;
+  // Combined character count to have buffered before declaring "ready", so playback doesn't
+  // outrun the buffer right after the first utterance.
+  readyBufferChars?: number;
 }
 
 const DEFAULT_PREFETCH_WINDOW = 3;
+// ~30s of speech at an average reading pace (~150wpm, ~5 chars/word) — an unmeasured guess at
+// how much buffer is needed to outlast a typical synth request, not tuned against real latency.
+const DEFAULT_READY_BUFFER_CHARS = 400;
 
 interface SynthesizeResult {
   audioUrl: string;
@@ -74,9 +80,11 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   private speakInContentLanguage: boolean = false;
   private speakGeneration: number = 0;
+  private loadGeneration: number = 0;
 
   // Rolling buffer of upcoming utterances' audio, fetched one at a time via prefetchChainTail.
   private readonly prefetchWindow: number;
+  private readonly readyBufferChars: number;
   private prefetchCache: Map<number, Promise<SynthesizeResult>> = new Map();
   private prefetchChainTail: Promise<void> = Promise.resolve();
 
@@ -94,6 +102,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     this.baseUrl = options.baseUrl.replace(/\/$/, "");
     this.fetchImpl = options.fetch ?? fetch.bind(globalThis);
     this.prefetchWindow = options.prefetchWindow ?? DEFAULT_PREFETCH_WINDOW;
+    this.readyBufferChars = options.readyBufferChars ?? DEFAULT_READY_BUFFER_CHARS;
   }
 
   // Lets a provider that already fetched /voices seed this engine without a second request.
@@ -105,8 +114,50 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
     this.clearPrefetchCache();
     this.currentUtterances = contents;
     this.currentUtteranceIndex = 0;
+    this.setState("loading");
+    void this.bufferUntilReady(++this.loadGeneration);
+  }
+
+  // Buffers enough leading utterances to cover readyBufferChars before declaring "ready",
+  // so playback doesn't catch up to an empty prefetch cache right after the first utterance.
+  private async bufferUntilReady(generation: number): Promise<void> {
+    // Bounded by prefetchWindow too — the initial buffer is just the front of that same
+    // lookahead, not a second, larger one.
+    const targetIndex = Math.min(this.indexCoveringChars(this.readyBufferChars), this.prefetchWindow);
+    const pending: Promise<SynthesizeResult>[] = [];
+    for (let index = 0; index <= targetIndex; index++) {
+      this.queuePrefetch(index);
+      const cached = this.prefetchCache.get(index);
+      if (cached) {
+        pending.push(cached);
+      }
+    }
+
+    try {
+      await Promise.all(pending);
+    } catch {
+      // A failed prefetch still unblocks "ready" — the actual error surfaces when speak() retries it.
+    }
+
+    if (generation !== this.loadGeneration) {
+      return;
+    }
     this.setState("ready");
     this.emitEvent({ type: "ready" });
+  }
+
+  private indexCoveringChars(targetChars: number): number {
+    if (this.currentUtterances.length === 0) {
+      return -1;
+    }
+    let total = 0;
+    for (let index = 0; index < this.currentUtterances.length; index++) {
+      total += (utteranceText(this.currentUtterances[index]) ?? "").length;
+      if (total >= targetChars) {
+        return index;
+      }
+    }
+    return this.currentUtterances.length - 1;
   }
 
   setVoice(voice: ReadiumSpeechVoice | string): void {
@@ -371,6 +422,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   stop(): void {
     this.speakGeneration++;
+    this.loadGeneration++;
     this.stopAudio();
     this.clearPrefetchCache();
     this.currentUtteranceIndex = 0;

--- a/src/SpeechServer/speechServerEngine.ts
+++ b/src/SpeechServer/speechServerEngine.ts
@@ -203,15 +203,28 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
   setVoice(voice: ReadiumSpeechVoice | string): void {
     if (typeof voice === "string") {
       const found = this.voices.find(v => v.identifier === voice || v.name === voice);
-      // Not cached yet — the server accepts a raw identifier/originalName directly.
-      this.currentVoice = found ?? {
-        source: "server",
-        label: voice,
-        name: voice,
-        originalName: voice,
-        language: "",
-        identifier: voice
-      };
+      if (found) {
+        this.currentVoice = found;
+      } else {
+        // Placeholder has no `controls` — resolve the real voice in the background so it's not mistaken for one the server can't adjust speed on.
+        this.currentVoice = {
+          source: "server",
+          label: voice,
+          name: voice,
+          originalName: voice,
+          language: "",
+          identifier: voice
+        };
+        void this.getAvailableVoices().then(voices => {
+          if (this.currentVoice?.identifier !== voice) {
+            return; // setVoice() was called again in the meantime
+          }
+          const match = voices.find(v => v.identifier === voice || v.name === voice);
+          if (match) {
+            this.currentVoice = match;
+          }
+        }).catch(() => {});
+      }
     } else {
       this.currentVoice = voice;
     }

--- a/src/SpeechServer/speechServerEngine.ts
+++ b/src/SpeechServer/speechServerEngine.ts
@@ -1,0 +1,416 @@
+import { ReadiumSpeechPlaybackEngine } from "../engine";
+import { ReadiumSpeechPlaybackEvent, ReadiumSpeechPlaybackState } from "../navigator";
+import { ReadiumSpeechUtterance } from "../utterance";
+import { ReadiumSpeechVoice } from "../voices/types";
+import { mapServerVoice } from "./speechServerVoiceMapping";
+import { toSpeechServerError } from "./errors";
+import { SpeechServerSynthesizeBoundaryResponse, SpeechServerTimingMark, SpeechServerVoice } from "./types";
+
+export interface SpeechServerEngineOptions {
+  baseUrl: string;
+  fetch?: typeof fetch;
+}
+
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+function mimeTypeForFormat(format: string): string {
+  switch (format) {
+    case "mp3":
+      return "audio/mpeg";
+    case "opus":
+      return "audio/ogg";
+    case "wav":
+    default:
+      return "audio/wav";
+  }
+}
+
+// <audio>.playbackRate has no reliable browser-enforced range; most engines
+// distort or silently clamp outside ~0.25-4.
+function clampPlaybackRate(rate: number): number {
+  return Math.max(0.25, Math.min(4, rate));
+}
+
+export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
+  private baseUrl: string;
+  private fetchImpl: typeof fetch;
+
+  private currentVoice: ReadiumSpeechVoice | null = null;
+  private voices: ReadiumSpeechVoice[] = [];
+  private currentUtterances: ReadiumSpeechUtterance[] = [];
+  private currentUtteranceIndex: number = 0;
+  private playbackState: ReadiumSpeechPlaybackState = "idle";
+  private eventListeners: Map<ReadiumSpeechPlaybackEvent["type"], ((event: ReadiumSpeechPlaybackEvent) => void)[]> = new Map();
+
+  private speakInContentLanguage: boolean = false;
+  private speakGeneration: number = 0;
+
+  private audio: HTMLAudioElement | null = null;
+  private audioObjectUrl: string | null = null;
+  private boundaryMarks: SpeechServerTimingMark[] = [];
+  private nextBoundaryIndex: number = 0;
+  private onTimeUpdate = (): void => this.checkBoundaries();
+
+  private rate: number = 1.0;
+  private pitch: number = 1.0;
+  private volume: number = 1.0;
+
+  constructor(options: SpeechServerEngineOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.fetchImpl = options.fetch ?? fetch.bind(globalThis);
+  }
+
+  // Lets a provider that already fetched /voices seed this engine without a second request.
+  setAvailableVoices(voices: ReadiumSpeechVoice[]): void {
+    this.voices = voices;
+  }
+
+  // Queue Management
+  loadUtterances(contents: ReadiumSpeechUtterance[]): void {
+    this.currentUtterances = contents;
+    this.currentUtteranceIndex = 0;
+    this.setState("ready");
+    this.emitEvent({ type: "ready" });
+  }
+
+  // Voice Configuration
+  setVoice(voice: ReadiumSpeechVoice | string): void {
+    if (typeof voice === "string") {
+      const found = this.voices.find(v => v.identifier === voice || v.name === voice);
+      // Not in the cached list yet (e.g. a raw identifier set before getAvailableVoices())
+      // — the server accepts a raw identifier/originalName directly, so keep it usable.
+      this.currentVoice = found ?? {
+        source: "server",
+        label: voice,
+        name: voice,
+        originalName: voice,
+        language: "",
+        identifier: voice
+      };
+    } else {
+      this.currentVoice = voice;
+    }
+  }
+
+  getCurrentVoice(): ReadiumSpeechVoice | null {
+    return this.currentVoice;
+  }
+
+  async getAvailableVoices(): Promise<ReadiumSpeechVoice[]> {
+    if (this.voices.length > 0) {
+      return this.voices;
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}/voices`);
+    if (!response.ok) {
+      throw await toSpeechServerError(response);
+    }
+    const serverVoices: SpeechServerVoice[] = await response.json();
+    this.voices = serverVoices.map(mapServerVoice);
+    return this.voices;
+  }
+
+  setSpeakInContentLanguage(enabled: boolean): void {
+    this.speakInContentLanguage = enabled;
+  }
+
+  getSpeakInContentLanguage(): boolean {
+    return this.speakInContentLanguage;
+  }
+
+  // Playback Control
+  speak(utteranceIndex?: number): void {
+    if (utteranceIndex !== undefined) {
+      if (utteranceIndex < 0 || utteranceIndex >= this.currentUtterances.length) {
+        throw new Error("Invalid utterance index");
+      }
+      this.currentUtteranceIndex = utteranceIndex;
+    }
+
+    if (this.currentUtterances.length === 0) {
+      console.warn("No utterances loaded");
+      return;
+    }
+
+    this.stopAudio();
+    const generation = ++this.speakGeneration;
+    this.setState("loading"); // emits "loading" itself, via the state-change switch below
+
+    void this.synthesizeAndPlay(generation);
+  }
+
+  private async synthesizeAndPlay(generation: number): Promise<void> {
+    const content = this.currentUtterances[this.currentUtteranceIndex];
+
+    try {
+      const { audioUrl, format, boundaries } = await this.synthesize(content);
+
+      if (generation !== this.speakGeneration) {
+        URL.revokeObjectURL(audioUrl);
+        return;
+      }
+
+      this.playAudio(audioUrl, format, boundaries, generation);
+    } catch (error) {
+      if (generation !== this.speakGeneration) {
+        return;
+      }
+      this.setState("idle");
+      this.emitEvent({
+        type: "error",
+        detail: error instanceof Error ? { message: error.message } : { message: String(error) }
+      });
+    }
+  }
+
+  private async synthesize(content: ReadiumSpeechUtterance): Promise<{
+    audioUrl: string;
+    format: string;
+    boundaries: SpeechServerTimingMark[] | null;
+  }> {
+    const useSSML = !content.plain && !!content.ssml;
+    const language = this.speakInContentLanguage ? content.language : undefined;
+
+    const response = await this.fetchImpl(`${this.baseUrl}/synthesize`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: content.id,
+        text: content.plain ?? content.ssml ?? "",
+        ssml: useSSML,
+        language,
+        voice: this.currentVoice?.identifier ?? this.currentVoice?.name,
+        boundary: true,
+        output: { speed: this.rate, pitch: this.pitch }
+      })
+    });
+
+    if (!response.ok) {
+      throw await toSpeechServerError(response);
+    }
+
+    const json: SpeechServerSynthesizeBoundaryResponse = await response.json();
+    const buffer = base64ToArrayBuffer(json.audio);
+    const blob = new Blob([buffer], { type: mimeTypeForFormat(json.format) });
+    const audioUrl = URL.createObjectURL(blob);
+
+    return { audioUrl, format: json.format, boundaries: json.boundaries };
+  }
+
+  private playAudio(url: string, _format: string, boundaries: SpeechServerTimingMark[] | null, generation: number): void {
+    const audio = new Audio(url);
+    this.audio = audio;
+    this.audioObjectUrl = url;
+    this.boundaryMarks = boundaries ?? [];
+    this.nextBoundaryIndex = 0;
+
+    audio.volume = Math.max(0, Math.min(1, this.volume));
+    // Only fake the rate on playback when the voice won't honor `output.speed` itself
+    // (true today for every PocketTTS voice) — otherwise a future provider that does
+    // apply server-side speed would get sped up twice.
+    const speedHonoredByServer = this.currentVoice?.controls?.speed === true;
+    audio.playbackRate = speedHonoredByServer ? 1 : clampPlaybackRate(this.rate);
+
+    audio.addEventListener("timeupdate", this.onTimeUpdate);
+
+    audio.onended = () => {
+      if (generation !== this.speakGeneration) {
+        return;
+      }
+      this.checkBoundaries();
+      if (this.currentUtteranceIndex >= this.currentUtterances.length - 1) {
+        this.setState("idle");
+      }
+      this.emitEvent({ type: "end" });
+    };
+
+    audio.onerror = () => {
+      if (generation !== this.speakGeneration) {
+        return;
+      }
+      this.setState("idle");
+      this.emitEvent({ type: "error", detail: { message: "Audio playback failed" } });
+    };
+
+    this.setState("playing");
+    this.emitEvent({ type: "start" });
+    void audio.play();
+  }
+
+  private checkBoundaries(): void {
+    const audio = this.audio;
+    if (!audio) {
+      return;
+    }
+    while (
+      this.nextBoundaryIndex < this.boundaryMarks.length &&
+      audio.currentTime >= this.boundaryMarks[this.nextBoundaryIndex].elapsedTime
+    ) {
+      const mark = this.boundaryMarks[this.nextBoundaryIndex];
+      this.emitEvent({
+        type: "boundary",
+        detail: {
+          name: mark.name,
+          charIndex: mark.charIndex,
+          charLength: mark.charLength,
+          elapsedTime: mark.elapsedTime
+        }
+      });
+      this.nextBoundaryIndex++;
+    }
+  }
+
+  private stopAudio(): void {
+    if (this.audio) {
+      this.audio.pause();
+      this.audio.removeEventListener("timeupdate", this.onTimeUpdate);
+      this.audio.src = "";
+      this.audio = null;
+    }
+    if (this.audioObjectUrl) {
+      URL.revokeObjectURL(this.audioObjectUrl);
+      this.audioObjectUrl = null;
+    }
+    this.boundaryMarks = [];
+    this.nextBoundaryIndex = 0;
+  }
+
+  pause(): void {
+    if (this.playbackState === "playing" && this.audio) {
+      this.audio.pause();
+      this.setState("paused");
+      this.emitEvent({ type: "pause" });
+    }
+  }
+
+  resume(): void {
+    if (this.playbackState === "paused" && this.audio) {
+      void this.audio.play();
+      this.setState("playing");
+      this.emitEvent({ type: "resume" });
+    }
+  }
+
+  stop(): void {
+    this.speakGeneration++;
+    this.stopAudio();
+    this.currentUtteranceIndex = 0;
+    this.setState("idle");
+    this.emitEvent({ type: "stop" });
+  }
+
+  // Playback Parameters
+  setRate(rate: number): void {
+    this.rate = Math.max(0.1, Math.min(10, rate));
+  }
+
+  getRate(): number {
+    return this.rate;
+  }
+
+  setPitch(pitch: number): void {
+    this.pitch = Math.max(0, Math.min(2, pitch));
+  }
+
+  getPitch(): number {
+    return this.pitch;
+  }
+
+  setVolume(volume: number): void {
+    this.volume = Math.max(0, Math.min(1, volume));
+    if (this.audio) {
+      this.audio.volume = this.volume;
+    }
+  }
+
+  getVolume(): number {
+    return this.volume;
+  }
+
+  // State
+  getState(): ReadiumSpeechPlaybackState {
+    return this.playbackState;
+  }
+
+  getCurrentUtteranceIndex(): number {
+    return this.currentUtteranceIndex;
+  }
+
+  setCurrentUtteranceIndex(index: number, onComplete?: (success: boolean) => void): void {
+    if (index < 0 || index >= this.currentUtterances.length) {
+      onComplete?.(false);
+      return;
+    }
+    if (index === this.currentUtteranceIndex) {
+      onComplete?.(true);
+      return;
+    }
+
+    this.stopAudio();
+    this.currentUtteranceIndex = index;
+    onComplete?.(true);
+  }
+
+  getUtteranceCount(): number {
+    return this.currentUtterances.length;
+  }
+
+  // Events
+  on(event: ReadiumSpeechPlaybackEvent["type"], callback: (event: ReadiumSpeechPlaybackEvent) => void): () => void {
+    if (!this.eventListeners.has(event)) {
+      this.eventListeners.set(event, []);
+    }
+    this.eventListeners.get(event)!.push(callback);
+
+    return () => {
+      const listeners = this.eventListeners.get(event);
+      if (listeners) {
+        const index = listeners.indexOf(callback);
+        if (index > -1) {
+          listeners.splice(index, 1);
+        }
+      }
+    };
+  }
+
+  private emitEvent(event: ReadiumSpeechPlaybackEvent): void {
+    const listeners = this.eventListeners.get(event.type);
+    if (listeners) {
+      listeners.forEach(callback => callback(event));
+    }
+  }
+
+  private setState(state: ReadiumSpeechPlaybackState): void {
+    const oldState = this.playbackState;
+    this.playbackState = state;
+
+    if (oldState !== state) {
+      switch (state) {
+        case "idle":
+          this.emitEvent({ type: "idle" });
+          break;
+        case "loading":
+          this.emitEvent({ type: "loading" });
+          break;
+        case "ready":
+          this.emitEvent({ type: "ready" });
+          break;
+      }
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.stop();
+    this.eventListeners.clear();
+    this.currentUtterances = [];
+    this.currentVoice = null;
+    this.voices = [];
+  }
+}

--- a/src/SpeechServer/speechServerEngine.ts
+++ b/src/SpeechServer/speechServerEngine.ts
@@ -473,7 +473,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
       this.masterGain.connect(this.audioContext.destination);
     }
     if (this.audioContext.state === "suspended") {
-      void this.audioContext.resume();
+      this.audioContext.resume().catch(() => {});
     }
     return this.audioContext;
   }
@@ -614,7 +614,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   pause(): void {
     if (this.playbackState === "playing" && this.audioContext) {
-      void this.audioContext.suspend();
+      this.audioContext.suspend().catch(() => {});
       this.stopBoundaryPolling();
       this.setState("paused");
       this.emitEvent({ type: "pause" });
@@ -623,7 +623,7 @@ export class SpeechServerEngine implements ReadiumSpeechPlaybackEngine {
 
   resume(): void {
     if (this.playbackState === "paused" && this.audioContext) {
-      void this.audioContext.resume();
+      this.audioContext.resume().catch(() => {});
       this.startBoundaryPolling(this.speakGeneration);
       this.setState("playing");
       this.emitEvent({ type: "resume" });

--- a/src/SpeechServer/speechServerEngineProvider.ts
+++ b/src/SpeechServer/speechServerEngineProvider.ts
@@ -1,30 +1,26 @@
 import { ReadiumSpeechEngineProvider } from "../provider";
 import { ReadiumSpeechPlaybackEngine } from "../engine";
 import { ReadiumSpeechVoice } from "../voices/types";
-import { SpeechServerEngine } from "./speechServerEngine";
+import { SpeechServerEngine, SpeechServerEngineOptions } from "./speechServerEngine";
 import { mapServerVoice } from "./speechServerVoiceMapping";
 import { toSpeechServerError } from "./errors";
 import { SpeechServerVoice } from "./types";
 
-export interface SpeechServerEngineProviderOptions {
-  baseUrl: string;
-  fetch?: typeof fetch;
-  prefetchWindow?: number;
-}
+// Reuses SpeechServerEngineOptions wholesale (not a hand-picked subset) so every option the
+// engine accepts is also available through the provider, with nothing to keep in sync.
+export type SpeechServerEngineProviderOptions = SpeechServerEngineOptions;
 
 export class SpeechServerEngineProvider implements ReadiumSpeechEngineProvider {
   readonly id: string = "speech-server";
   readonly name: string = "Readium Speech Server";
 
-  private baseUrl: string;
+  private options: SpeechServerEngineProviderOptions;
   private fetchImpl: typeof fetch;
-  private prefetchWindow: number | undefined;
   private voices: ReadiumSpeechVoice[] = [];
 
   constructor(options: SpeechServerEngineProviderOptions) {
-    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.options = options;
     this.fetchImpl = options.fetch ?? fetch.bind(globalThis);
-    this.prefetchWindow = options.prefetchWindow;
   }
 
   async getVoices(): Promise<ReadiumSpeechVoice[]> {
@@ -32,7 +28,7 @@ export class SpeechServerEngineProvider implements ReadiumSpeechEngineProvider {
       return this.voices;
     }
 
-    const response = await this.fetchImpl(`${this.baseUrl}/voices`);
+    const response = await this.fetchImpl(this.options.endpoints.voices);
     if (!response.ok) {
       throw await toSpeechServerError(response);
     }
@@ -42,7 +38,7 @@ export class SpeechServerEngineProvider implements ReadiumSpeechEngineProvider {
   }
 
   async createEngine(voice?: ReadiumSpeechVoice | string): Promise<ReadiumSpeechPlaybackEngine> {
-    const engine = new SpeechServerEngine({ baseUrl: this.baseUrl, fetch: this.fetchImpl, prefetchWindow: this.prefetchWindow });
+    const engine = new SpeechServerEngine(this.options);
     if (this.voices.length > 0) {
       engine.setAvailableVoices(this.voices);
     }

--- a/src/SpeechServer/speechServerEngineProvider.ts
+++ b/src/SpeechServer/speechServerEngineProvider.ts
@@ -9,6 +9,7 @@ import { SpeechServerVoice } from "./types";
 export interface SpeechServerEngineProviderOptions {
   baseUrl: string;
   fetch?: typeof fetch;
+  prefetchWindow?: number;
 }
 
 export class SpeechServerEngineProvider implements ReadiumSpeechEngineProvider {
@@ -17,11 +18,13 @@ export class SpeechServerEngineProvider implements ReadiumSpeechEngineProvider {
 
   private baseUrl: string;
   private fetchImpl: typeof fetch;
+  private prefetchWindow: number | undefined;
   private voices: ReadiumSpeechVoice[] = [];
 
   constructor(options: SpeechServerEngineProviderOptions) {
     this.baseUrl = options.baseUrl.replace(/\/$/, "");
     this.fetchImpl = options.fetch ?? fetch.bind(globalThis);
+    this.prefetchWindow = options.prefetchWindow;
   }
 
   async getVoices(): Promise<ReadiumSpeechVoice[]> {
@@ -39,7 +42,7 @@ export class SpeechServerEngineProvider implements ReadiumSpeechEngineProvider {
   }
 
   async createEngine(voice?: ReadiumSpeechVoice | string): Promise<ReadiumSpeechPlaybackEngine> {
-    const engine = new SpeechServerEngine({ baseUrl: this.baseUrl, fetch: this.fetchImpl });
+    const engine = new SpeechServerEngine({ baseUrl: this.baseUrl, fetch: this.fetchImpl, prefetchWindow: this.prefetchWindow });
     if (this.voices.length > 0) {
       engine.setAvailableVoices(this.voices);
     }

--- a/src/SpeechServer/speechServerEngineProvider.ts
+++ b/src/SpeechServer/speechServerEngineProvider.ts
@@ -1,0 +1,55 @@
+import { ReadiumSpeechEngineProvider } from "../provider";
+import { ReadiumSpeechPlaybackEngine } from "../engine";
+import { ReadiumSpeechVoice } from "../voices/types";
+import { SpeechServerEngine } from "./speechServerEngine";
+import { mapServerVoice } from "./speechServerVoiceMapping";
+import { toSpeechServerError } from "./errors";
+import { SpeechServerVoice } from "./types";
+
+export interface SpeechServerEngineProviderOptions {
+  baseUrl: string;
+  fetch?: typeof fetch;
+}
+
+export class SpeechServerEngineProvider implements ReadiumSpeechEngineProvider {
+  readonly id: string = "speech-server";
+  readonly name: string = "Readium Speech Server";
+
+  private baseUrl: string;
+  private fetchImpl: typeof fetch;
+  private voices: ReadiumSpeechVoice[] = [];
+
+  constructor(options: SpeechServerEngineProviderOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.fetchImpl = options.fetch ?? fetch.bind(globalThis);
+  }
+
+  async getVoices(): Promise<ReadiumSpeechVoice[]> {
+    if (this.voices.length > 0) {
+      return this.voices;
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}/voices`);
+    if (!response.ok) {
+      throw await toSpeechServerError(response);
+    }
+    const serverVoices: SpeechServerVoice[] = await response.json();
+    this.voices = serverVoices.map(mapServerVoice);
+    return this.voices;
+  }
+
+  async createEngine(voice?: ReadiumSpeechVoice | string): Promise<ReadiumSpeechPlaybackEngine> {
+    const engine = new SpeechServerEngine({ baseUrl: this.baseUrl, fetch: this.fetchImpl });
+    if (this.voices.length > 0) {
+      engine.setAvailableVoices(this.voices);
+    }
+    if (voice) {
+      engine.setVoice(voice);
+    }
+    return engine;
+  }
+
+  async destroy(): Promise<void> {
+    this.voices = [];
+  }
+}

--- a/src/SpeechServer/speechServerVoiceMapping.ts
+++ b/src/SpeechServer/speechServerVoiceMapping.ts
@@ -1,0 +1,18 @@
+import { ReadiumSpeechVoice } from "../voices/types";
+import { SpeechServerVoice } from "./types";
+
+export function mapServerVoice(voice: SpeechServerVoice): ReadiumSpeechVoice {
+  return {
+    source: "server",
+    label: voice.name,
+    name: voice.name,
+    originalName: voice.originalName,
+    language: voice.language,
+    otherLanguages: voice.otherLanguages,
+    gender: voice.gender ?? undefined,
+    quality: voice.quality,
+    provider: voice.provider,
+    identifier: voice.identifier,
+    controls: voice.controls
+  };
+}

--- a/src/SpeechServer/types.ts
+++ b/src/SpeechServer/types.ts
@@ -19,7 +19,7 @@ export interface SpeechServerTimingMark {
   elapsedTime: number;
 }
 
-export type SpeechServerAudioFormat = "wav" | "mp3" | "opus";
+export type SpeechServerAudioFormat = "wav" | "mp3" | "opus" | "aac" | "flac" | "ogg" | "webm" | "m4a";
 
 export interface SpeechServerSynthesizeRequest {
   id?: string;

--- a/src/SpeechServer/types.ts
+++ b/src/SpeechServer/types.ts
@@ -1,0 +1,53 @@
+import { TGender, TQuality, TServerVoiceControls } from "../voices/types";
+
+export interface SpeechServerVoice {
+  name: string;
+  originalName: string;
+  provider: string;
+  identifier: string;
+  language: string;
+  otherLanguages?: string[];
+  gender?: TGender | null;
+  quality?: TQuality;
+  controls?: TServerVoiceControls;
+}
+
+export interface SpeechServerTimingMark {
+  name: "word" | "sentence";
+  charIndex: number;
+  charLength: number;
+  elapsedTime: number;
+}
+
+export type SpeechServerAudioFormat = "wav" | "mp3" | "opus";
+
+export interface SpeechServerSynthesizeRequest {
+  id?: string;
+  text: string;
+  ssml?: boolean;
+  language?: string;
+  voice?: string;
+  prev_utterance?: string;
+  next_utterance?: string;
+  publication_id?: string;
+  boundary?: boolean;
+  output?: {
+    format?: SpeechServerAudioFormat;
+    bitrate?: number | null;
+    sample_rate?: number | null;
+    speed?: number;
+    pitch?: number | null;
+  };
+}
+
+export interface SpeechServerSynthesizeBoundaryResponse {
+  audio: string;
+  format: SpeechServerAudioFormat;
+  boundaries: SpeechServerTimingMark[] | null;
+}
+
+export interface SpeechServerServiceInfo {
+  output: { formats: SpeechServerAudioFormat[]; default: SpeechServerAudioFormat };
+  limits: { maxTextLength: number; maxConcurrentSyntheses: number };
+  providers: { id: string; installedLanguages: string[] }[];
+}

--- a/src/WebSpeech/index.ts
+++ b/src/WebSpeech/index.ts
@@ -1,5 +1,3 @@
 export * from "./WebSpeechVoiceManager";
 export * from "./webSpeechEngine";
 export * from "./webSpeechEngineProvider";
-
-export * from "./TmpNavigator";

--- a/src/WebSpeech/webSpeechEngineProvider.ts
+++ b/src/WebSpeech/webSpeechEngineProvider.ts
@@ -7,13 +7,14 @@ export class WebSpeechEngineProvider implements ReadiumSpeechEngineProvider {
   readonly id: string = "webspeech";
   readonly name: string = "Web Speech API";
 
-  private engine: WebSpeechEngine | null = null;
+  private voiceEngine: WebSpeechEngine | null = null;
 
   async getVoices(): Promise<ReadiumSpeechVoice[]> {
-    if (!this.engine) {
-      throw new Error("No engine available. Create an engine first.");
+    if (!this.voiceEngine) {
+      this.voiceEngine = new WebSpeechEngine();
+      await this.voiceEngine.initialize();
     }
-    return this.engine.getAvailableVoices();
+    return this.voiceEngine.getAvailableVoices();
   }
 
   async createEngine(voice?: ReadiumSpeechVoice | string): Promise<ReadiumSpeechPlaybackEngine> {
@@ -26,9 +27,9 @@ export class WebSpeechEngineProvider implements ReadiumSpeechEngineProvider {
   }
 
   async destroy(): Promise<void> {
-    if (this.engine) {
-      await this.engine.destroy();
-      this.engine = null;
+    if (this.voiceEngine) {
+      await this.voiceEngine.destroy();
+      this.voiceEngine = null;
     }
   }
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -3,6 +3,11 @@ import { ReadiumSpeechUtterance } from "./utterance";
 import { ReadiumSpeechVoice } from "./voices/types";
 
 export interface ReadiumSpeechPlaybackEngine {
+  // Lifecycle hook a navigator can call after construction, before first use
+  // (e.g. WebSpeechEngine loading its voice list). Engines that don't need
+  // async setup, such as SpeechServerEngine, can omit it.
+  initialize?(): Promise<unknown>;
+
   // Queue Management
   loadUtterances(contents: ReadiumSpeechUtterance[]): void;
   

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export * from "./voices/types";
 export * from "./engine";
 export * from "./navigator";
 export * from "./provider";
+export * from "./providerRegistry";
+export * from "./speechNavigator";
 export * from "./utterance";
 export * from "./gnd";
 export * from "./utterances";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Core exports
 export * from "./WebSpeech";
+export * from "./SpeechServer";
 
 // Decorator re-exports
 export * from "@readium/decorator";

--- a/src/navigator.ts
+++ b/src/navigator.ts
@@ -22,9 +22,7 @@ export interface ReadiumSpeechPlaybackEvent {
   detail?: any;  // Event-specific data
 }
 
-// This should evolve dramatically as WebSpeech is kind of an outlier
-// And it will be impacted by adapters from external services
-export interface ReadiumSpeechNavigator {
+export interface ReadiumSpeechNavigatorContract {
   // Voice Management
   getVoices(): Promise<ReadiumSpeechVoice[]>;
   setVoice(voice: ReadiumSpeechVoice | string): void;

--- a/src/providerRegistry.ts
+++ b/src/providerRegistry.ts
@@ -1,0 +1,66 @@
+import { ReadiumSpeechEngineProvider } from "./provider";
+import { ReadiumSpeechPlaybackEngine } from "./engine";
+import { ReadiumSpeechVoice } from "./voices/types";
+
+export interface ReadiumSpeechProviderVoices {
+  providerId: string;
+  voices: ReadiumSpeechVoice[];
+}
+
+// A voice's own `provider` field already means something else per source
+// (e.g. speech-server's backend id, "pocket", not the registry id "speech-server";
+// unset for WebSpeech). So voices are never flattened across providers here —
+// callers that want one merged list do that themselves, keeping track of which
+// group (providerId) a picked voice came from.
+export class ReadiumSpeechProviderRegistry {
+  private providers: Map<string, ReadiumSpeechEngineProvider> = new Map();
+
+  register(provider: ReadiumSpeechEngineProvider): void {
+    if (this.providers.has(provider.id)) {
+      throw new Error(`A provider is already registered under id "${provider.id}"`);
+    }
+    this.providers.set(provider.id, provider);
+  }
+
+  unregister(providerId: string): void {
+    this.providers.delete(providerId);
+  }
+
+  get(providerId: string): ReadiumSpeechEngineProvider | undefined {
+    return this.providers.get(providerId);
+  }
+
+  list(): ReadiumSpeechEngineProvider[] {
+    return [...this.providers.values()];
+  }
+
+  async getVoices(providerId: string): Promise<ReadiumSpeechVoice[]> {
+    return this.require(providerId).getVoices();
+  }
+
+  async getAllVoices(): Promise<ReadiumSpeechProviderVoices[]> {
+    return Promise.all(
+      this.list().map(async (provider) => ({
+        providerId: provider.id,
+        voices: await provider.getVoices()
+      }))
+    );
+  }
+
+  async createEngine(providerId: string, voice?: ReadiumSpeechVoice | string): Promise<ReadiumSpeechPlaybackEngine> {
+    return this.require(providerId).createEngine(voice);
+  }
+
+  async destroy(): Promise<void> {
+    await Promise.all(this.list().map((provider) => provider.destroy()));
+    this.providers.clear();
+  }
+
+  private require(providerId: string): ReadiumSpeechEngineProvider {
+    const provider = this.providers.get(providerId);
+    if (!provider) {
+      throw new Error(`No provider registered under id "${providerId}"`);
+    }
+    return provider;
+  }
+}

--- a/src/speechNavigator.ts
+++ b/src/speechNavigator.ts
@@ -1,10 +1,9 @@
-import { ReadiumSpeechPlaybackEngine } from "../engine";
-import { ReadiumSpeechNavigator, ReadiumSpeechPlaybackEvent, ReadiumSpeechPlaybackState } from "../navigator";
-import { ReadiumSpeechUtterance } from "../utterance";
-import { ReadiumSpeechVoice } from "../voices/types";
-import { WebSpeechEngine } from "./webSpeechEngine";
+import { ReadiumSpeechPlaybackEngine } from "./engine";
+import { ReadiumSpeechNavigatorContract, ReadiumSpeechPlaybackEvent, ReadiumSpeechPlaybackState } from "./navigator";
+import { ReadiumSpeechUtterance } from "./utterance";
+import { ReadiumSpeechVoice } from "./voices/types";
 
-export class WebSpeechReadAloudNavigator implements ReadiumSpeechNavigator {
+export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
   private engine: ReadiumSpeechPlaybackEngine;
   private contentQueue: ReadiumSpeechUtterance[] = [];
   private eventListeners: Map<ReadiumSpeechPlaybackEvent["type"] | "contentchange", ((event: ReadiumSpeechPlaybackEvent) => void)[]> = new Map();
@@ -12,19 +11,17 @@ export class WebSpeechReadAloudNavigator implements ReadiumSpeechNavigator {
   // Navigator owns the state, not the engine
   private navigatorState: ReadiumSpeechPlaybackState = "idle";
 
-  constructor(engine?: ReadiumSpeechPlaybackEngine) {
-    this.engine = engine || new WebSpeechEngine();
+  constructor(engine: ReadiumSpeechPlaybackEngine) {
+    this.engine = engine;
     this.setupEngineListeners();
-    this.initializeEngine();
+    void this.initializeEngine();
   }
 
   private async initializeEngine(): Promise<void> {
-    if (this.engine instanceof WebSpeechEngine) {
-      try {
-        await this.engine.initialize();
-      } catch (error) {
-        console.warn("Failed to initialize WebSpeechEngine:", error);
-      }
+    try {
+      await this.engine.initialize?.();
+    } catch (error) {
+      console.warn("Failed to initialize speech engine:", error);
     }
   }
 
@@ -46,7 +43,7 @@ export class WebSpeechReadAloudNavigator implements ReadiumSpeechNavigator {
         // Reached end - set navigator to idle
         this.setNavigatorState("idle");
       }
-      
+
       this.emitEvent({ type: "end" });
     });
 
@@ -176,7 +173,7 @@ export class WebSpeechReadAloudNavigator implements ReadiumSpeechNavigator {
 
   private skipToPosition(targetIndex: number, forcePlay: boolean = false): boolean {
     const currentIndex = this.getCurrentUtteranceIndex();
-    
+
     // Check if the target index is valid
     if (targetIndex < 0 || targetIndex >= this.contentQueue.length) {
       return false;
@@ -201,7 +198,7 @@ export class WebSpeechReadAloudNavigator implements ReadiumSpeechNavigator {
       this.setNavigatorState("playing");
       this.engine.speak(targetIndex);
     }
-    
+
     return true;
   }
 

--- a/src/speechNavigator.ts
+++ b/src/speechNavigator.ts
@@ -121,11 +121,12 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
     const contents = Array.isArray(content) ? content : [content];
     this.contentQueue = [...contents];
 
-    // Load utterances first
+    // Readiness comes from the engine's own "ready" event (see setupEngineListeners),
+    // not set here — engines that buffer ahead (e.g. SpeechServerEngine) fire it once
+    // they're confident playback won't immediately stall.
+    this.setNavigatorState("loading");
+    this.emitEvent({ type: "loading" });
     this.engine.loadUtterances(contents);
-
-    // Then set navigator state to ready
-    this.setNavigatorState("ready");
     this.emitContentChangeEvent({ content: contents });
   }
 

--- a/src/voices/types.ts
+++ b/src/voices/types.ts
@@ -16,7 +16,18 @@ export type TLocalizedName = "android" | "apple";
 /**
  * Source of the voice data
  */
-export type TSource = "json" | "browser";
+export type TSource = "json" | "browser" | "server";
+
+/**
+ * Controls a speech-server voice reports as enabled, e.g. {ssml: true}.
+ * A control absent from this object is not supported by that voice.
+ */
+export interface TServerVoiceControls {
+  pitch?: boolean;
+  speed?: boolean;
+  ssml?: boolean;
+  boundary?: boolean;
+}
 
 /**
  * Supported operating systems for voices
@@ -90,7 +101,9 @@ export interface ReadiumSpeechVoice {
   
   // Additional metadata
   note?: string;          // Additional notes about the voice
-  provider?: string;      // Voice provider (e.g., "Microsoft", "Google")
+  provider?: string;      // Voice provider (e.g., "Microsoft", "Google", or a speech-server provider id)
+  identifier?: string;    // Opaque id to send back to a server provider (e.g. a speech-server voice URN)
+  controls?: TServerVoiceControls; // Which playback controls a server-sourced voice actually honors
 
   // Runtime-derived flags
   isDefault?: boolean;    // Whether this is the platform's default voice

--- a/test/SpeechServer/chunkText.test.ts
+++ b/test/SpeechServer/chunkText.test.ts
@@ -1,0 +1,124 @@
+import test from "ava";
+import { chunkPlainText, chunkSsmlText } from "../../build/index.js";
+
+function reconstruct(chunks: { text: string; offset: number }[]): string {
+  return chunks.map(c => c.text).join("");
+}
+
+// =============================================
+// chunkPlainText
+// =============================================
+
+test("chunkPlainText returns the text unchanged as a single chunk when under budget", (t) => {
+  const chunks = chunkPlainText("Short sentence.", 100);
+  t.deepEqual(chunks, [{ text: "Short sentence.", offset: 0 }]);
+});
+
+test("chunkPlainText splits multiple sentences at sentence boundaries once over budget", (t) => {
+  const text = "First sentence. Second sentence. Third sentence.";
+  const chunks = chunkPlainText(text, 20);
+
+  t.true(chunks.length > 1);
+  for (const chunk of chunks) {
+    t.true(chunk.text.length <= 20, `chunk "${chunk.text}" exceeds budget`);
+  }
+  t.is(reconstruct(chunks), text, "chunks concatenate back into the exact original text");
+  for (const chunk of chunks) {
+    t.is(text.slice(chunk.offset, chunk.offset + chunk.text.length), chunk.text, "offset matches the original text");
+  }
+});
+
+test("chunkPlainText falls back to word-boundary packing when a single sentence exceeds the budget", (t) => {
+  const text = "This one sentence by itself is much longer than the tiny budget allowed here.";
+  const chunks = chunkPlainText(text, 20);
+
+  t.true(chunks.length > 1);
+  for (const chunk of chunks) {
+    t.true(chunk.text.length <= 20, `chunk "${chunk.text}" exceeds budget`);
+  }
+  t.is(reconstruct(chunks), text);
+  // No chunk boundary lands mid-word: every chunk (but possibly the last) ends on whitespace.
+  for (const chunk of chunks.slice(0, -1)) {
+    t.regex(chunk.text, /\s$/, `chunk "${chunk.text}" should end on whitespace, not mid-word`);
+  }
+});
+
+test("chunkPlainText hard-splits a single word longer than the budget as a last resort", (t) => {
+  const text = "Supercalifragilisticexpialidocious";
+  const chunks = chunkPlainText(text, 10);
+
+  t.true(chunks.length > 1);
+  for (const chunk of chunks) {
+    t.true(chunk.text.length <= 10);
+  }
+  t.is(reconstruct(chunks), text);
+});
+
+test("chunkPlainText: an atom exceeding maxLength alone is still emitted as its own oversized chunk", (t) => {
+  // A single "word" with no spaces, longer than the budget and not further divisible cleanly,
+  // still comes back as one chunk if hard-splitting isn't triggered (word == budget edge case).
+  const chunks = chunkPlainText("word.", 4);
+  t.true(chunks.every(c => c.text.length > 0));
+  t.is(reconstruct(chunks), "word.");
+});
+
+test("chunkPlainText splits CJK text at full-width sentence punctuation, with no space required between sentences", (t) => {
+  const text = "这是一个测试句子。这是第二个句子！这是第三个句子？".repeat(3);
+  const chunks = chunkPlainText(text, 15);
+
+  t.true(chunks.length > 1);
+  t.is(reconstruct(chunks), text, "no text is dropped even though CJK sentences run together with no whitespace");
+  for (const chunk of chunks) {
+    t.true(chunk.text.length <= 15, `chunk "${chunk.text}" exceeds budget`);
+  }
+});
+
+test("chunkPlainText never splits a surrogate pair (e.g. an emoji) during a hard character split", (t) => {
+  const text = "\u{1F600}".repeat(20); // 20 emoji, no whitespace/punctuation to split on
+  const chunks = chunkPlainText(text, 15);
+
+  t.is(reconstruct(chunks), text);
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.text.length; i++) {
+      const code = chunk.text.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = chunk.text.charCodeAt(i + 1);
+        t.true(next >= 0xdc00 && next <= 0xdfff, `chunk "${chunk.text}" ends mid-surrogate-pair`);
+      }
+    }
+  }
+});
+
+// =============================================
+// chunkSsmlText
+// =============================================
+
+test("chunkSsmlText returns the text unchanged as a single chunk when under budget", (t) => {
+  const text = "Hello <lang xml:lang=\"fr\">bonjour</lang> there.";
+  const chunks = chunkSsmlText(text, 100);
+  t.deepEqual(chunks, [{ text, offset: 0 }]);
+});
+
+test("chunkSsmlText never splits inside a tag span", (t) => {
+  const text = "Hello <lang xml:lang=\"fr\">bonjour tout le monde</lang> and <lang xml:lang=\"es\">hola a todos</lang> there my friend.";
+  const chunks = chunkSsmlText(text, 30);
+
+  t.true(chunks.length > 1);
+  t.is(reconstruct(chunks), text, "chunks concatenate back into the exact original text");
+  for (const chunk of chunks) {
+    const openTags = (chunk.text.match(/<lang\b[^>]*>/g) ?? []).length;
+    const closeTags = (chunk.text.match(/<\/lang>/g) ?? []).length;
+    t.is(openTags, closeTags, `chunk "${chunk.text}" has an unbalanced <lang> tag`);
+  }
+});
+
+test("chunkSsmlText emits a single atomic tag span exceeding maxLength as one oversized chunk", (t) => {
+  const text = "Hi. <lang xml:lang=\"fr\">this whole tagged phrase is longer than the tiny budget</lang> bye.";
+  const chunks = chunkSsmlText(text, 15);
+
+  t.is(reconstruct(chunks), text);
+  const tagChunk = chunks.find(c => c.text.includes("<lang"));
+  t.truthy(tagChunk);
+  t.true(tagChunk!.text.length > 15, "the tag span chunk is allowed to exceed the budget rather than being corrupted");
+  t.regex(tagChunk!.text, /^<lang[^>]*>.*<\/lang>$/, "the tag span is emitted whole, unsplit");
+});

--- a/test/SpeechServer/selectFormat.test.ts
+++ b/test/SpeechServer/selectFormat.test.ts
@@ -1,0 +1,167 @@
+import test from "ava";
+import { selectFormat, selectBitrate, mimeTypeForFormat, CanPlayTypeResult } from "../../build/index.js";
+
+function canPlayAll(): CanPlayTypeResult {
+  return "probably";
+}
+
+function canPlayNone(): CanPlayTypeResult {
+  return "";
+}
+
+function canPlayOnly(...mimes: string[]): (mime: string) => CanPlayTypeResult {
+  return (mime: string) => (mimes.includes(mime) ? "maybe" : "");
+}
+
+// =============================================
+// selectFormat
+// =============================================
+
+test("selectFormat returns the explicit preferredFormat when it's advertised and playable", (t) => {
+  const format = selectFormat(
+    { formats: ["wav", "mp3", "opus"], default: "wav" },
+    { preferredFormat: "opus" },
+    canPlayAll
+  );
+  t.is(format, "opus");
+});
+
+test("selectFormat falls back to strategy ranking when preferredFormat isn't playable", (t) => {
+  const format = selectFormat(
+    { formats: ["wav", "mp3", "opus"], default: "wav" },
+    { preferredFormat: "opus", strategy: "quality" },
+    canPlayOnly("audio/wav", "audio/mpeg")
+  );
+  t.is(format, "wav", "opus isn't playable, so quality ranking picks wav next");
+});
+
+test("selectFormat falls back to strategy ranking when preferredFormat isn't server-advertised", (t) => {
+  const format = selectFormat(
+    { formats: ["wav", "mp3"], default: "wav" },
+    { preferredFormat: "opus", strategy: "bandwidth" },
+    canPlayAll
+  );
+  t.is(format, "mp3", "opus is playable but not advertised, so bandwidth ranking picks the best of what's left");
+});
+
+test("selectFormat \"quality\" strategy prefers wav > opus > mp3", (t) => {
+  const format = selectFormat(
+    { formats: ["mp3", "opus", "wav"], default: "mp3" },
+    { strategy: "quality" },
+    canPlayAll
+  );
+  t.is(format, "wav");
+});
+
+test("selectFormat \"bandwidth\" strategy prefers opus > mp3 > wav", (t) => {
+  const format = selectFormat(
+    { formats: ["mp3", "opus", "wav"], default: "mp3" },
+    { strategy: "bandwidth" },
+    canPlayAll
+  );
+  t.is(format, "opus");
+});
+
+test("selectFormat defaults to \"quality\" strategy when none is specified", (t) => {
+  const format = selectFormat(
+    { formats: ["mp3", "opus", "wav"], default: "mp3" },
+    {},
+    canPlayAll
+  );
+  t.is(format, "wav");
+});
+
+test("selectFormat falls back to output.default when nothing advertised is playable", (t) => {
+  const format = selectFormat(
+    { formats: ["wav", "mp3", "opus"], default: "mp3" },
+    { strategy: "quality" },
+    canPlayNone
+  );
+  t.is(format, "mp3");
+});
+
+test("selectFormat treats \"maybe\" as playable, not just \"probably\"", (t) => {
+  const format = selectFormat(
+    { formats: ["wav"], default: "wav" },
+    {},
+    () => "maybe"
+  );
+  t.is(format, "wav");
+});
+
+test("selectFormat still picks a format the rank tables don't know about, over falling back to output.default", (t) => {
+  const format = selectFormat(
+    { formats: ["mp3", "flac9000"], default: "mp3" },
+    { strategy: "quality" },
+    canPlayOnly(mimeTypeForFormat("flac9000")) // only the unknown format is playable
+  );
+  t.is(format, "flac9000", "confirmed playable but unranked beats falling back to output.default");
+});
+
+test("selectFormat ranks a known format over an unranked-but-playable one", (t) => {
+  const format = selectFormat(
+    { formats: ["mp3", "flac9000"], default: "mp3" },
+    { strategy: "quality" },
+    canPlayAll
+  );
+  t.is(format, "mp3", "a format in the rank table still wins over an unranked one when both are playable");
+});
+
+test("selectFormat's widened rank tables cover aac/flac/ogg/webm, not just wav/mp3/opus", (t) => {
+  const quality = selectFormat({ formats: ["mp3", "aac", "flac"], default: "mp3" }, { strategy: "quality" }, canPlayAll);
+  t.is(quality, "flac", "flac (lossless) ranks above aac under \"quality\"");
+
+  const bandwidth = selectFormat({ formats: ["webm", "ogg", "wav"], default: "wav" }, { strategy: "bandwidth" }, canPlayAll);
+  t.is(bandwidth, "webm", "webm ranks above ogg/wav under \"bandwidth\"");
+});
+
+// =============================================
+// mimeTypeForFormat
+// =============================================
+
+test("mimeTypeForFormat covers the widened known-format set", (t) => {
+  t.is(mimeTypeForFormat("aac"), "audio/aac");
+  t.is(mimeTypeForFormat("flac"), "audio/flac");
+  t.is(mimeTypeForFormat("ogg"), "audio/ogg");
+  t.is(mimeTypeForFormat("webm"), "audio/webm");
+  t.is(mimeTypeForFormat("m4a"), "audio/mp4");
+});
+
+test("mimeTypeForFormat guesses honestly for an unrecognized format instead of mislabeling it as wav", (t) => {
+  t.is(mimeTypeForFormat("weirdcodec"), "audio/weirdcodec");
+});
+
+// =============================================
+// selectBitrate
+// =============================================
+
+test("selectBitrate returns undefined when adaptBitrateToNetwork is off", (t) => {
+  t.is(selectBitrate("mp3", false, { saveData: true }), undefined);
+});
+
+test("selectBitrate returns undefined when there's no network info", (t) => {
+  t.is(selectBitrate("mp3", true, undefined), undefined);
+});
+
+test("selectBitrate reduces bitrate when saveData is true", (t) => {
+  t.is(selectBitrate("mp3", true, { saveData: true }), 48000);
+  t.is(selectBitrate("opus", true, { saveData: true }), 24000);
+});
+
+test("selectBitrate reduces bitrate on a 2G-class effectiveType", (t) => {
+  t.is(selectBitrate("mp3", true, { effectiveType: "slow-2g" }), 48000);
+  t.is(selectBitrate("mp3", true, { effectiveType: "2g" }), 48000);
+});
+
+test("selectBitrate leaves bitrate unset on a fast connection", (t) => {
+  t.is(selectBitrate("mp3", true, { effectiveType: "4g" }), undefined);
+});
+
+test("selectBitrate never reduces wav or flac, regardless of network", (t) => {
+  t.is(selectBitrate("wav", true, { saveData: true }), undefined);
+  t.is(selectBitrate("flac", true, { saveData: true }), undefined);
+});
+
+test("selectBitrate leaves an unrecognized format's bitrate untouched", (t) => {
+  t.is(selectBitrate("flac9000", true, { saveData: true }), undefined, "no known reduced value for this format, so no adaptation happens");
+});

--- a/test/SpeechServer/speechServerEngine.test.ts
+++ b/test/SpeechServer/speechServerEngine.test.ts
@@ -72,6 +72,37 @@ test.serial("speak() POSTs /synthesize with the loaded utterance and current voi
   t.is(body.language, undefined, "language omitted when speakInContentLanguage is off");
 });
 
+test.serial("speak() sends the queue's neighboring utterances as prev_utterance/next_utterance", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "First." }, { plain: "Second." }, { plain: "Third." }]);
+
+  engine.speak(1);
+  await flush();
+
+  const body = JSON.parse(calls[0].init.body);
+  t.is(body.text, "Second.");
+  t.is(body.prev_utterance, "First.");
+  t.is(body.next_utterance, "Third.");
+});
+
+test.serial("prev_utterance/next_utterance are omitted at the start/end of the queue", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Only one." }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls[0].init.body);
+  t.is(body.prev_utterance, undefined);
+  t.is(body.next_utterance, undefined);
+});
+
 test.serial("ssml-only content (no plain) is sent as text with ssml:true", async (t) => {
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
@@ -198,6 +229,125 @@ test.serial("pause/resume control the underlying audio element", async (t) => {
   t.is(engine.getState(), "playing");
 });
 
+test.serial("speak() prefetches the next utterance while the current one plays", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl, prefetchWindow: 1 });
+  engine.loadUtterances([{ plain: "First." }, { plain: "Second." }, { plain: "Third." }]);
+
+  engine.speak(0);
+  await flush();
+
+  const synthCalls = calls.filter(c => c.url.endsWith("/synthesize"));
+  t.is(synthCalls.length, 2, "prefetch for the next utterance fires without waiting for the current one to end");
+  t.is(JSON.parse(synthCalls[0].init.body).text, "First.");
+  t.is(JSON.parse(synthCalls[1].init.body).text, "Second.");
+});
+
+test.serial("the default prefetch window buffers several utterances ahead, not just one", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([
+    { plain: "One" }, { plain: "Two" }, { plain: "Three" }, { plain: "Four" }, { plain: "Five" }
+  ]);
+
+  engine.speak(0);
+  await flush();
+
+  const texts = calls.filter(c => c.url.endsWith("/synthesize")).map(c => JSON.parse(c.init.body).text);
+  t.deepEqual(texts, ["One", "Two", "Three", "Four"], "current utterance plus 3 ahead (the default window), not the whole queue");
+});
+
+test.serial("prefetch requests are chained: never more than one /synthesize in flight at once", async (t) => {
+  const calls: string[] = [];
+  const pending: Array<() => void> = [];
+
+  const fetchImpl = (async (url: string, init?: any) => {
+    if (!url.endsWith("/synthesize")) {
+      throw new Error(`Unhandled mock fetch URL: ${url}`);
+    }
+    calls.push(JSON.parse(init.body).text);
+    await new Promise<void>((resolve) => pending.push(resolve));
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({ audio: wavBase64(), format: "wav", boundaries: null })
+    };
+  }) as unknown as typeof fetch;
+
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl, prefetchWindow: 3 });
+  engine.loadUtterances([{ plain: "One" }, { plain: "Two" }, { plain: "Three" }, { plain: "Four" }]);
+
+  engine.speak(0);
+  await flush();
+  t.deepEqual(calls, ["One"], "only the current utterance's own request has been sent so far");
+
+  pending.shift()!();
+  await flush();
+  t.deepEqual(calls, ["One", "Two"], "prefetch for the next utterance starts once the current one's request resolves");
+
+  pending.shift()!();
+  await flush();
+  t.deepEqual(calls, ["One", "Two", "Three"], "the following prefetch only starts once the previous one resolves, not concurrently");
+
+  pending.shift()!();
+  await flush();
+  t.deepEqual(calls, ["One", "Two", "Three", "Four"]);
+});
+
+test.serial("a completed prefetch is reused instead of triggering a second fetch", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "First." }, { plain: "Second." }]);
+
+  engine.speak(0);
+  await flush();
+  t.is(calls.filter(c => c.url.endsWith("/synthesize")).length, 2, "First. fetched, Second. prefetched");
+
+  engine.speak(1);
+  await flush();
+  t.is(calls.filter(c => c.url.endsWith("/synthesize")).length, 2, "speak(1) reused the prefetch instead of fetching again");
+});
+
+test.serial("changing rate invalidates a pending prefetch", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "First." }, { plain: "Second." }]);
+
+  engine.speak(0);
+  await flush();
+  t.is(calls.filter(c => c.url.endsWith("/synthesize")).length, 2);
+
+  engine.setRate(2);
+  engine.speak(1);
+  await flush();
+
+  const synthCalls = calls.filter(c => c.url.endsWith("/synthesize"));
+  t.is(synthCalls.length, 3, "the rate-2 speak(1) re-fetched instead of reusing the stale rate-1 prefetch");
+  t.is(JSON.parse(synthCalls[2].init.body).output.speed, 2);
+});
+
+test.serial("no prefetch happens past the end of the queue", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Only one." }]);
+
+  engine.speak(0);
+  await flush();
+
+  t.is(calls.filter(c => c.url.endsWith("/synthesize")).length, 1);
+});
+
 test.serial("stop() resets to idle and index 0", async (t) => {
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
@@ -218,7 +368,7 @@ test.serial("a non-ok /synthesize response surfaces as an error event, not a thr
       status: 404,
       ok: false,
       json: {
-        type: "https://readium.org/speech-server/error#voice_not_found",
+        type: "urn:example:voice-not-found",
         title: "Voice Not Found",
         status: 404,
         detail: "Voice 'x' not found."
@@ -237,6 +387,8 @@ test.serial("a non-ok /synthesize response surfaces as an error event, not a thr
 
   t.is(errors.length, 1);
   t.is(errors[0].message, "Voice 'x' not found.");
+  t.is(errors[0].status, 404);
+  t.is(errors[0].type, "urn:example:voice-not-found");
   t.is(engine.getState(), "idle");
 });
 

--- a/test/SpeechServer/speechServerEngine.test.ts
+++ b/test/SpeechServer/speechServerEngine.test.ts
@@ -505,6 +505,42 @@ test.serial("rate is only faked locally when the voice's controls don't report s
   t.is(MockAudioBufferSourceNode.instances[1].playbackRate.value, 1, "server is trusted to apply speed itself, no local doubling");
 });
 
+test.serial("setVoice(string) with an uncached identifier resolves controls.speed in the background, avoiding a doubled rate once resolved", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    voices: () => [makeServerVoice({ controls: { speed: true } })],
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.setRate(2);
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  // Voice list isn't cached yet, so this only has a placeholder with no `controls` at first.
+  engine.setVoice("urn:readium:tts:pocket:alba");
+  t.is(engine.getCurrentVoice()?.controls, undefined, "placeholder has no controls yet, right after setVoice()");
+
+  await flush(); // background getAvailableVoices() resolves
+
+  t.deepEqual(engine.getCurrentVoice()?.controls, { speed: true }, "placeholder was swapped for the real, cached voice");
+
+  engine.speak();
+  await flush();
+  t.is(MockAudioBufferSourceNode.instances[0].playbackRate.value, 1, "server-honored speed is trusted, not doubled with a local fallback");
+});
+
+test.serial("setVoice(string) called again before the background voice lookup resolves doesn't get overwritten by the stale lookup", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    voices: () => [makeServerVoice({ controls: { speed: true } }), makeServerVoice({ name: "Estelle", identifier: "urn:readium:tts:pocket:estelle", controls: {} })]
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+
+  engine.setVoice("urn:readium:tts:pocket:alba");
+  engine.setVoice("urn:readium:tts:pocket:estelle"); // supersedes the still-pending lookup for "alba"
+  await flush();
+
+  t.is(engine.getCurrentVoice()?.identifier, "urn:readium:tts:pocket:estelle", "the later setVoice() call wins, not the earlier one's background resolution");
+  t.deepEqual(engine.getCurrentVoice()?.controls, {}, "estelle's own resolved controls, not alba's");
+});
+
 test.serial("setVolume applies to the shared gain node", async (t) => {
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })

--- a/test/SpeechServer/speechServerEngine.test.ts
+++ b/test/SpeechServer/speechServerEngine.test.ts
@@ -3,58 +3,127 @@ import { SpeechServerEngine, chunkPlainText } from "../../build/index.js";
 import { createMockFetch, makeServerVoice, wavBase64, flush, defaultServiceInfo } from "./testUtils.js";
 
 // =============================================
-// Mock <audio>
+// Mock <audio> (canPlayType probing only)
 // =============================================
-// SpeechServerEngine drives playback through a real HTMLAudioElement in the
-// browser; Node has no such global, so this stands in for it.
+// The engine's `canPlayType` field probes `new Audio().canPlayType(mime)` to pick an output
+// format; Node has no such global, so this stands in for it. Actual playback goes through
+// Web Audio (see the AudioContext mocks below), not this class.
 
 class MockAudio {
-  static instances: MockAudio[] = [];
-
-  src: string;
-  currentTime = 0;
-  volume = 1;
-  playbackRate = 1;
-  onended: (() => void) | null = null;
-  onerror: (() => void) | null = null;
-  private listeners: Record<string, Array<() => void>> = {};
-
-  // No src means this instance exists only to probe canPlayType() (see engine's
-  // `canPlayType` field) — it's never actually played, so it's excluded from `instances`,
-  // which tests use to inspect the real playback elements created per chunk.
-  constructor(src?: string) {
-    this.src = src ?? "";
-    if (src) {
-      MockAudio.instances.push(this);
-    }
-  }
-
-  addEventListener(type: string, cb: () => void): void {
-    (this.listeners[type] ??= []).push(cb);
-  }
-
-  removeEventListener(type: string, cb: () => void): void {
-    this.listeners[type] = (this.listeners[type] || []).filter(l => l !== cb);
-  }
-
-  play(): Promise<void> {
-    return Promise.resolve();
-  }
-
-  pause(): void {}
-
   canPlayType(_mime: string): string {
     return "probably";
   }
+}
 
-  emitTimeUpdate(): void {
-    (this.listeners["timeupdate"] || []).forEach(cb => cb());
+// =============================================
+// Mock Web Audio API
+// =============================================
+// SpeechServerEngine drives playback through AudioContext/AudioBufferSourceNode in the
+// browser; Node has no such globals, so these stand in for them.
+
+class MockAudioBuffer {
+  constructor(public duration: number) {}
+}
+
+class MockGainNode {
+  static instances: MockGainNode[] = [];
+  gain = { value: 1 };
+  constructor() {
+    MockGainNode.instances.push(this);
+  }
+  connect(): void {}
+  disconnect(): void {}
+}
+
+class MockAudioBufferSourceNode {
+  static instances: MockAudioBufferSourceNode[] = [];
+  buffer: MockAudioBuffer | null = null;
+  playbackRate = { value: 1 };
+  onended: (() => void) | null = null;
+  startedAt: number | null = null;
+  constructor() {
+    MockAudioBufferSourceNode.instances.push(this);
+  }
+  connect(): void {}
+  disconnect(): void {}
+  start(t: number): void {
+    this.startedAt = t;
+  }
+  stop(): void {}
+}
+
+class MockAudioContext {
+  static instances: MockAudioContext[] = [];
+  // Consumed FIFO by decodeAudioData, one entry per call; falls back to 1s once exhausted.
+  static decodeDurations: number[] = [];
+
+  currentTime = 0;
+  state: "running" | "suspended" | "closed" = "running";
+  destination = {};
+
+  constructor() {
+    MockAudioContext.instances.push(this);
+  }
+
+  createGain(): MockGainNode {
+    return new MockGainNode();
+  }
+
+  createBufferSource(): MockAudioBufferSourceNode {
+    return new MockAudioBufferSourceNode();
+  }
+
+  decodeAudioData(_buffer: ArrayBuffer): Promise<MockAudioBuffer> {
+    const duration = MockAudioContext.decodeDurations.shift() ?? 1;
+    return Promise.resolve(new MockAudioBuffer(duration));
+  }
+
+  suspend(): Promise<void> {
+    this.state = "suspended";
+    return Promise.resolve();
+  }
+
+  resume(): Promise<void> {
+    this.state = "running";
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this.state = "closed";
+    return Promise.resolve();
   }
 }
 
+// Fake requestAnimationFrame/cancelAnimationFrame: queues callbacks instead of firing on a
+// real clock, so tests drive boundary polling deterministically via driveFrame().
+let rafCallbacks = new Map<number, (t: number) => void>();
+let rafNextId = 1;
+
+function driveFrame(): void {
+  const callbacks = Array.from(rafCallbacks.values());
+  rafCallbacks.clear();
+  callbacks.forEach(cb => cb(0));
+}
+
 test.beforeEach(() => {
-  MockAudio.instances = [];
   (globalThis as any).Audio = MockAudio;
+
+  MockAudioContext.instances = [];
+  MockAudioContext.decodeDurations = [];
+  MockAudioBufferSourceNode.instances = [];
+  MockGainNode.instances = [];
+  (globalThis as any).AudioContext = MockAudioContext;
+
+  rafCallbacks = new Map();
+  rafNextId = 1;
+  (globalThis as any).requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = rafNextId++;
+    rafCallbacks.set(id, cb);
+    return id;
+  };
+  (globalThis as any).cancelAnimationFrame = (id: number) => {
+    rafCallbacks.delete(id);
+  };
 });
 
 // =============================================
@@ -192,12 +261,12 @@ test.serial("speak() plays audio and fires loading/start/end events", async (t) 
   t.deepEqual(events, ["loading", "start"]);
   t.is(engine.getState(), "playing");
 
-  MockAudio.instances[0].onended?.();
+  MockAudioBufferSourceNode.instances[0].onended?.();
   t.deepEqual(events, ["loading", "start", "end"]);
   t.is(engine.getState(), "idle", "state is idle after the last (only) utterance ends");
 });
 
-test.serial("boundary marks fire as audio.currentTime crosses each mark's elapsedTime", async (t) => {
+test.serial("boundary marks fire as the AudioContext clock crosses each mark's elapsedTime", async (t) => {
   const marks = [
     { name: "word", charIndex: 0, charLength: 5, elapsedTime: 0 },
     { name: "word", charIndex: 6, charLength: 5, elapsedTime: 0.5 }
@@ -214,19 +283,19 @@ test.serial("boundary marks fire as audio.currentTime crosses each mark's elapse
   engine.speak();
   await flush();
 
-  const audio = MockAudio.instances[0];
-  audio.currentTime = 0;
-  audio.emitTimeUpdate();
+  const ctx = MockAudioContext.instances[0];
+  ctx.currentTime = 0;
+  driveFrame();
   t.is(boundaries.length, 1);
   t.is(boundaries[0].charIndex, 0);
 
-  audio.currentTime = 0.5;
-  audio.emitTimeUpdate();
+  ctx.currentTime = 0.5;
+  driveFrame();
   t.is(boundaries.length, 2);
   t.is(boundaries[1].charIndex, 6);
 });
 
-test.serial("pause/resume control the underlying audio element", async (t) => {
+test.serial("pause/resume control the underlying AudioContext", async (t) => {
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
@@ -235,11 +304,15 @@ test.serial("pause/resume control the underlying audio element", async (t) => {
   engine.speak();
   await flush();
 
+  const ctx = MockAudioContext.instances[0];
+
   engine.pause();
   t.is(engine.getState(), "paused");
+  t.is(ctx.state, "suspended");
 
   engine.resume();
   t.is(engine.getState(), "playing");
+  t.is(ctx.state, "running");
 });
 
 test.serial("speak() prefetches the next utterance while the current one plays", async (t) => {
@@ -424,15 +497,15 @@ test.serial("rate is only faked locally when the voice's controls don't report s
   engine.setVoice(makeServerVoice({ controls: {} }) as any);
   engine.speak();
   await flush();
-  t.is(MockAudio.instances[0].playbackRate, 2, "local fallback applies since controls.speed isn't true");
+  t.is(MockAudioBufferSourceNode.instances[0].playbackRate.value, 2, "local fallback applies since controls.speed isn't true");
 
   engine.setVoice(makeServerVoice({ controls: { speed: true } }) as any);
   engine.speak();
   await flush();
-  t.is(MockAudio.instances[1].playbackRate, 1, "server is trusted to apply speed itself, no local doubling");
+  t.is(MockAudioBufferSourceNode.instances[1].playbackRate.value, 1, "server is trusted to apply speed itself, no local doubling");
 });
 
-test.serial("setVolume applies to the live audio element", async (t) => {
+test.serial("setVolume applies to the shared gain node", async (t) => {
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
@@ -442,7 +515,7 @@ test.serial("setVolume applies to the live audio element", async (t) => {
   await flush();
 
   engine.setVolume(0.4);
-  t.is(MockAudio.instances[0].volume, 0.4);
+  t.is(MockGainNode.instances[0].gain.value, 0.4);
 });
 
 test.serial("synthesize() requests /service's advertised default output format", async (t) => {
@@ -498,7 +571,82 @@ test.serial("text exceeding /service's maxTextLength is split into multiple sequ
   t.deepEqual(synthCalls.map(c => JSON.parse(c.init.body).text), expectedChunks.map(c => c.text));
 });
 
-test.serial("chunked utterance playback fires a single start/end pair across all chunks, chained via onended", async (t) => {
+test.serial("split chunks are capped at readyBufferChars, not the (larger) maxTextLength", async (t) => {
+  const maxTextLength = 40;
+  const readyBufferChars = 20;
+  const text = "First sentence here now. Second sentence follows too.";
+  const expectedChunks = chunkPlainText(text, readyBufferChars);
+  t.true(text.length > maxTextLength, "text must actually exceed maxTextLength, or splitting wouldn't happen at all");
+  t.true(chunkPlainText(text, maxTextLength).length < expectedChunks.length, "readyBufferChars must produce more/smaller chunks than maxTextLength alone would");
+
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength, maxConcurrentSyntheses: 2 } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    readyBufferChars
+  });
+  engine.loadUtterances([{ plain: text }]);
+
+  engine.speak();
+  await flush();
+
+  const synthCalls = calls.filter(c => c.url.endsWith("/synthesize"));
+  t.deepEqual(synthCalls.map(c => JSON.parse(c.init.body).text), expectedChunks.map(c => c.text));
+});
+
+test.serial("bufferUntilReady doesn't wait for a long utterance's entire chunk train, just its first chunk", async (t) => {
+  const maxTextLength = 20;
+  const readyBufferChars = 5; // smaller than the utterance's own text, so index 0 alone qualifies
+  const text = "First sentence here now. Second sentence follows too. And a third one here.";
+  const expectedChunkCount = chunkPlainText(text, Math.min(maxTextLength, readyBufferChars)).length;
+  t.true(expectedChunkCount > 1);
+
+  const pending: Array<() => void> = [];
+  let synthCount = 0;
+  const fetchImpl = (async (url: string) => {
+    if (url.endsWith("/service")) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: async () => ({ ...defaultServiceInfo(), limits: { maxTextLength, maxConcurrentSyntheses: 2 } })
+      };
+    }
+    if (!url.endsWith("/synthesize")) {
+      throw new Error(`Unhandled mock fetch URL: ${url}`);
+    }
+    synthCount++;
+    if (synthCount > 1) {
+      await new Promise<void>(resolve => pending.push(resolve));
+    }
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({ audio: wavBase64(), format: "wav", boundaries: null })
+    };
+  }) as unknown as typeof fetch;
+
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    readyBufferChars
+  });
+
+  const events: string[] = [];
+  engine.on("ready", () => events.push("ready"));
+
+  engine.loadUtterances([{ plain: text }]);
+  await flush();
+
+  t.true(events.includes("ready"), "ready fired despite later chunks of the same utterance still being in flight");
+  t.true(pending.length > 0, "sanity check: this test setup does leave later chunks unresolved");
+});
+
+test.serial("chunked utterance playback fires a single start/end pair across all chunks", async (t) => {
   const maxTextLength = 20;
   const text = "First sentence here now. Second sentence follows too.";
   const expectedChunkCount = chunkPlainText(text, maxTextLength).length;
@@ -518,19 +666,97 @@ test.serial("chunked utterance playback fires a single start/end pair across all
   engine.speak();
   await flush();
 
-  t.is(MockAudio.instances.length, 1, "only the first chunk's <audio> exists until it ends — the rest are created lazily");
+  t.is(MockAudioBufferSourceNode.instances.length, expectedChunkCount, "every chunk resolved and got scheduled by the time speak() settles");
   t.deepEqual(events, ["start"], "\"start\" fires once, for the logical utterance, not per chunk");
 
   for (let i = 0; i < expectedChunkCount - 1; i++) {
-    MockAudio.instances[i].onended?.();
-    t.is(MockAudio.instances.length, i + 2, "the next chunk's <audio> is created once the previous one ends");
-    t.deepEqual(events, ["start"], "\"end\" hasn't fired yet — chunks before the last just chain to the next");
+    t.is(MockAudioBufferSourceNode.instances[i].onended, null, "only the last chunk's node gets an onended handler");
   }
 
-  MockAudio.instances[expectedChunkCount - 1].onended?.();
-  t.is(MockAudio.instances.length, expectedChunkCount, "exactly one <audio> element was created per chunk overall");
-  t.deepEqual(events, ["start", "end"], "\"end\" fires once, only after the last chunk");
+  MockAudioBufferSourceNode.instances[expectedChunkCount - 1].onended?.();
+  t.deepEqual(events, ["start", "end"], "\"end\" fires once, only after the last chunk's node ends");
   t.is(engine.getState(), "idle");
+});
+
+test.serial("chunked utterance playback starts on the first chunk without waiting for the rest", async (t) => {
+  const maxTextLength = 20;
+  const text = "First sentence here now. Second sentence follows too. And a third one here.";
+  const expectedChunkCount = chunkPlainText(text, maxTextLength).length;
+  t.true(expectedChunkCount > 2, "need 3+ chunks to tell \"only chunk 0 ready\" apart from \"everything ready\"");
+
+  const pending: Array<() => void> = [];
+  let synthCount = 0;
+  const fetchImpl = (async (url: string) => {
+    if (url.endsWith("/service")) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: async () => ({ ...defaultServiceInfo(), limits: { maxTextLength, maxConcurrentSyntheses: 2 } })
+      };
+    }
+    if (!url.endsWith("/synthesize")) {
+      throw new Error(`Unhandled mock fetch URL: ${url}`);
+    }
+    synthCount++;
+    if (synthCount > 1) {
+      await new Promise<void>(resolve => pending.push(resolve));
+    }
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({ audio: wavBase64(), format: "wav", boundaries: null })
+    };
+  }) as unknown as typeof fetch;
+
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.loadUtterances([{ plain: text }]);
+
+  const events: string[] = [];
+  engine.on("start", () => events.push("start"));
+
+  engine.speak();
+  await flush();
+
+  t.deepEqual(events, ["start"], "playback starts once chunk 0 is ready, without waiting for chunks 1+");
+  t.is(MockAudioBufferSourceNode.instances.length, 1, "only chunk 0 is scheduled — the rest are still in flight");
+
+  pending.shift()!();
+  await flush();
+  t.is(MockAudioBufferSourceNode.instances.length, 2, "chunk 1 is appended to the schedule once its own request resolves");
+
+  while (pending.length > 0) {
+    pending.shift()!();
+    await flush();
+  }
+  t.is(MockAudioBufferSourceNode.instances.length, expectedChunkCount, "every chunk eventually gets scheduled");
+});
+
+test.serial("chunked utterance nodes are scheduled back-to-back with zero gap between them", async (t) => {
+  const maxTextLength = 20;
+  const text = "First sentence here now. Second sentence follows too. And a third one here.";
+  const expectedChunkCount = chunkPlainText(text, maxTextLength).length;
+  t.true(expectedChunkCount > 1);
+
+  const durations = [2, 3, 1.5, 4, 5]; // more than enough for any chunk count
+  MockAudioContext.decodeDurations = [...durations];
+
+  const { fetchImpl } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength, maxConcurrentSyntheses: 2 } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.loadUtterances([{ plain: text }]);
+
+  engine.speak();
+  await flush();
+
+  let expectedStart = 0;
+  for (let i = 0; i < expectedChunkCount; i++) {
+    t.is(MockAudioBufferSourceNode.instances[i].startedAt, expectedStart, `chunk ${i} starts exactly where the previous one ended`);
+    expectedStart += durations[i];
+  }
 });
 
 test.serial("boundary charIndex is offset by each chunk's position in the original utterance text", async (t) => {
@@ -554,14 +780,17 @@ test.serial("boundary charIndex is offset by each chunk's position in the origin
   engine.speak();
   await flush();
 
-  MockAudio.instances[0].currentTime = 0;
-  MockAudio.instances[0].emitTimeUpdate();
+  const ctx = MockAudioContext.instances[0];
+
+  ctx.currentTime = 0;
+  driveFrame();
   t.is(boundaries.length, 1);
   t.is(boundaries[0].charIndex, 2 + expectedChunks[0].offset, "first chunk's charIndex is offset by its (zero) position");
 
-  MockAudio.instances[0].onended?.();
-  MockAudio.instances[1].currentTime = 0;
-  MockAudio.instances[1].emitTimeUpdate();
+  // Chunks are scheduled back-to-back at 1s each (the mock's default decoded duration), so
+  // the second chunk's mark (elapsedTime: 0) crosses once the clock reaches its start time.
+  ctx.currentTime = 1;
+  driveFrame();
   t.is(boundaries.length, 2);
   t.true(expectedChunks[1].offset > 0, "test setup sanity check: the second chunk isn't at the start of the text");
   t.is(boundaries[1].charIndex, 2 + expectedChunks[1].offset, "second chunk's charIndex is offset by its position in the original text");

--- a/test/SpeechServer/speechServerEngine.test.ts
+++ b/test/SpeechServer/speechServerEngine.test.ts
@@ -1,0 +1,273 @@
+import test from "ava";
+import { SpeechServerEngine } from "../../build/index.js";
+import { createMockFetch, makeServerVoice, wavBase64, flush } from "./testUtils.js";
+
+// =============================================
+// Mock <audio>
+// =============================================
+// SpeechServerEngine drives playback through a real HTMLAudioElement in the
+// browser; Node has no such global, so this stands in for it.
+
+class MockAudio {
+  static instances: MockAudio[] = [];
+
+  src: string;
+  currentTime = 0;
+  volume = 1;
+  playbackRate = 1;
+  onended: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  private listeners: Record<string, Array<() => void>> = {};
+
+  constructor(src: string) {
+    this.src = src;
+    MockAudio.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: () => void): void {
+    (this.listeners[type] ??= []).push(cb);
+  }
+
+  removeEventListener(type: string, cb: () => void): void {
+    this.listeners[type] = (this.listeners[type] || []).filter(l => l !== cb);
+  }
+
+  play(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  pause(): void {}
+
+  emitTimeUpdate(): void {
+    (this.listeners["timeupdate"] || []).forEach(cb => cb());
+  }
+}
+
+test.beforeEach(() => {
+  MockAudio.instances = [];
+  (globalThis as any).Audio = MockAudio;
+});
+
+// =============================================
+// Tests
+// =============================================
+
+test.serial("speak() POSTs /synthesize with the loaded utterance and current voice identifier", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.setVoice(makeServerVoice() as any);
+  engine.loadUtterances([{ id: "u1", plain: "Hello world", language: "en" }]);
+
+  engine.speak();
+  await flush();
+
+  const synth = calls.find(c => c.url.endsWith("/synthesize"))!;
+  const body = JSON.parse(synth.init.body);
+  t.is(body.text, "Hello world");
+  t.is(body.ssml, false);
+  t.is(body.voice, "urn:readium:tts:pocket:alba");
+  t.is(body.boundary, true);
+  t.is(body.language, undefined, "language omitted when speakInContentLanguage is off");
+});
+
+test.serial("ssml-only content (no plain) is sent as text with ssml:true", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ ssml: "<p>Hi</p>" }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls[0].init.body);
+  t.is(body.text, "<p>Hi</p>");
+  t.is(body.ssml, true);
+});
+
+test.serial("plain takes priority over ssml when both are present", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Hi", ssml: "<p>Hi</p>" }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls[0].init.body);
+  t.is(body.text, "Hi");
+  t.is(body.ssml, false);
+});
+
+test.serial("setSpeakInContentLanguage(true) sends the utterance's own language", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.setSpeakInContentLanguage(true);
+  engine.loadUtterances([{ plain: "Bonjour", language: "fr" }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls[0].init.body);
+  t.is(body.language, "fr");
+});
+
+test.serial("setVoice(string) uses a cached voice when found, else keeps the raw identifier usable", async (t) => {
+  const { fetchImpl } = createMockFetch({ voices: () => [makeServerVoice()] });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+
+  await engine.getAvailableVoices();
+  engine.setVoice("urn:readium:tts:pocket:alba");
+  t.is(engine.getCurrentVoice()?.name, "Alba");
+
+  engine.setVoice("urn:readium:tts:pocket:unknown");
+  t.is(engine.getCurrentVoice()?.identifier, "urn:readium:tts:pocket:unknown");
+  t.is(engine.getCurrentVoice()?.source, "server");
+});
+
+test.serial("speak() plays audio and fires loading/start/end events", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  const events: string[] = [];
+  engine.on("loading", () => events.push("loading"));
+  engine.on("start", () => events.push("start"));
+  engine.on("end", () => events.push("end"));
+
+  engine.speak();
+  await flush();
+
+  t.deepEqual(events, ["loading", "start"]);
+  t.is(engine.getState(), "playing");
+
+  MockAudio.instances[0].onended?.();
+  t.deepEqual(events, ["loading", "start", "end"]);
+  t.is(engine.getState(), "idle", "state is idle after the last (only) utterance ends");
+});
+
+test.serial("boundary marks fire as audio.currentTime crosses each mark's elapsedTime", async (t) => {
+  const marks = [
+    { name: "word", charIndex: 0, charLength: 5, elapsedTime: 0 },
+    { name: "word", charIndex: 6, charLength: 5, elapsedTime: 0.5 }
+  ];
+  const { fetchImpl } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: marks } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Hello world" }]);
+
+  const boundaries: any[] = [];
+  engine.on("boundary", (e: any) => boundaries.push(e.detail));
+
+  engine.speak();
+  await flush();
+
+  const audio = MockAudio.instances[0];
+  audio.currentTime = 0;
+  audio.emitTimeUpdate();
+  t.is(boundaries.length, 1);
+  t.is(boundaries[0].charIndex, 0);
+
+  audio.currentTime = 0.5;
+  audio.emitTimeUpdate();
+  t.is(boundaries.length, 2);
+  t.is(boundaries[1].charIndex, 6);
+});
+
+test.serial("pause/resume control the underlying audio element", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Hello" }]);
+  engine.speak();
+  await flush();
+
+  engine.pause();
+  t.is(engine.getState(), "paused");
+
+  engine.resume();
+  t.is(engine.getState(), "playing");
+});
+
+test.serial("stop() resets to idle and index 0", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "One" }, { plain: "Two" }]);
+  engine.speak(1);
+  await flush();
+
+  engine.stop();
+  t.is(engine.getState(), "idle");
+  t.is(engine.getCurrentUtteranceIndex(), 0);
+});
+
+test.serial("a non-ok /synthesize response surfaces as an error event, not a thrown exception", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    synthesize: () => ({
+      status: 404,
+      ok: false,
+      json: {
+        type: "https://readium.org/speech-server/error#voice_not_found",
+        title: "Voice Not Found",
+        status: 404,
+        detail: "Voice 'x' not found."
+      },
+      contentType: "application/problem+json"
+    })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  const errors: any[] = [];
+  engine.on("error", (e: any) => errors.push(e.detail));
+
+  engine.speak();
+  await flush();
+
+  t.is(errors.length, 1);
+  t.is(errors[0].message, "Voice 'x' not found.");
+  t.is(engine.getState(), "idle");
+});
+
+test.serial("rate is only faked locally when the voice's controls don't report server-side speed support", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.setRate(2);
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  engine.setVoice(makeServerVoice({ controls: {} }) as any);
+  engine.speak();
+  await flush();
+  t.is(MockAudio.instances[0].playbackRate, 2, "local fallback applies since controls.speed isn't true");
+
+  engine.setVoice(makeServerVoice({ controls: { speed: true } }) as any);
+  engine.speak();
+  await flush();
+  t.is(MockAudio.instances[1].playbackRate, 1, "server is trusted to apply speed itself, no local doubling");
+});
+
+test.serial("setVolume applies to the live audio element", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Hello" }]);
+  engine.speak();
+  await flush();
+
+  engine.setVolume(0.4);
+  t.is(MockAudio.instances[0].volume, 0.4);
+});

--- a/test/SpeechServer/speechServerEngine.test.ts
+++ b/test/SpeechServer/speechServerEngine.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
-import { SpeechServerEngine } from "../../build/index.js";
-import { createMockFetch, makeServerVoice, wavBase64, flush } from "./testUtils.js";
+import { SpeechServerEngine, chunkPlainText } from "../../build/index.js";
+import { createMockFetch, makeServerVoice, wavBase64, flush, defaultServiceInfo } from "./testUtils.js";
 
 // =============================================
 // Mock <audio>
@@ -19,9 +19,14 @@ class MockAudio {
   onerror: (() => void) | null = null;
   private listeners: Record<string, Array<() => void>> = {};
 
-  constructor(src: string) {
-    this.src = src;
-    MockAudio.instances.push(this);
+  // No src means this instance exists only to probe canPlayType() (see engine's
+  // `canPlayType` field) — it's never actually played, so it's excluded from `instances`,
+  // which tests use to inspect the real playback elements created per chunk.
+  constructor(src?: string) {
+    this.src = src ?? "";
+    if (src) {
+      MockAudio.instances.push(this);
+    }
   }
 
   addEventListener(type: string, cb: () => void): void {
@@ -37,6 +42,10 @@ class MockAudio {
   }
 
   pause(): void {}
+
+  canPlayType(_mime: string): string {
+    return "probably";
+  }
 
   emitTimeUpdate(): void {
     (this.listeners["timeupdate"] || []).forEach(cb => cb());
@@ -56,7 +65,7 @@ test.serial("speak() POSTs /synthesize with the loaded utterance and current voi
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.setVoice(makeServerVoice() as any);
   engine.loadUtterances([{ id: "u1", plain: "Hello world", language: "en" }]);
 
@@ -76,13 +85,13 @@ test.serial("speak() sends the queue's neighboring utterances as prev_utterance/
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "First." }, { plain: "Second." }, { plain: "Third." }]);
 
   engine.speak(1);
   await flush();
 
-  const body = JSON.parse(calls.find(c => JSON.parse(c.init.body).text === "Second.")!.init.body);
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize") && JSON.parse(c.init.body).text === "Second.")!.init.body);
   t.is(body.text, "Second.");
   t.is(body.prev_utterance, "First.");
   t.is(body.next_utterance, "Third.");
@@ -92,13 +101,13 @@ test.serial("prev_utterance/next_utterance are omitted at the start/end of the q
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "Only one." }]);
 
   engine.speak();
   await flush();
 
-  const body = JSON.parse(calls[0].init.body);
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
   t.is(body.prev_utterance, undefined);
   t.is(body.next_utterance, undefined);
 });
@@ -107,13 +116,13 @@ test.serial("ssml-only content (no plain) is sent as text with ssml:true", async
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ ssml: "<p>Hi</p>" }]);
 
   engine.speak();
   await flush();
 
-  const body = JSON.parse(calls[0].init.body);
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
   t.is(body.text, "<p>Hi</p>");
   t.is(body.ssml, true);
 });
@@ -122,13 +131,13 @@ test.serial("plain takes priority over ssml when both are present", async (t) =>
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "Hi", ssml: "<p>Hi</p>" }]);
 
   engine.speak();
   await flush();
 
-  const body = JSON.parse(calls[0].init.body);
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
   t.is(body.text, "Hi");
   t.is(body.ssml, false);
 });
@@ -137,20 +146,20 @@ test.serial("setSpeakInContentLanguage(true) sends the utterance's own language"
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.setSpeakInContentLanguage(true);
   engine.loadUtterances([{ plain: "Bonjour", language: "fr" }]);
 
   engine.speak();
   await flush();
 
-  const body = JSON.parse(calls[0].init.body);
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
   t.is(body.language, "fr");
 });
 
 test.serial("setVoice(string) uses a cached voice when found, else keeps the raw identifier usable", async (t) => {
   const { fetchImpl } = createMockFetch({ voices: () => [makeServerVoice()] });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
 
   await engine.getAvailableVoices();
   engine.setVoice("urn:readium:tts:pocket:alba");
@@ -165,7 +174,7 @@ test.serial("speak() plays audio and fires loading/start/end events", async (t) 
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
 
   const events: string[] = [];
   engine.on("loading", () => events.push("loading"));
@@ -196,7 +205,7 @@ test.serial("boundary marks fire as audio.currentTime crosses each mark's elapse
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: marks } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "Hello world" }]);
 
   const boundaries: any[] = [];
@@ -221,7 +230,7 @@ test.serial("pause/resume control the underlying audio element", async (t) => {
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "Hello" }]);
   engine.speak();
   await flush();
@@ -237,7 +246,7 @@ test.serial("speak() prefetches the next utterance while the current one plays",
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl, prefetchWindow: 1 });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl, prefetchWindow: 1 });
   engine.loadUtterances([{ plain: "First." }, { plain: "Second." }, { plain: "Third." }]);
 
   engine.speak(0);
@@ -253,7 +262,7 @@ test.serial("the default prefetch window buffers several utterances ahead, not j
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([
     { plain: "One" }, { plain: "Two" }, { plain: "Three" }, { plain: "Four" }, { plain: "Five" }
   ]);
@@ -270,6 +279,14 @@ test.serial("prefetch requests are chained: never more than one /synthesize in f
   const pending: Array<() => void> = [];
 
   const fetchImpl = (async (url: string, init?: any) => {
+    if (url.endsWith("/service")) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => "application/json" },
+        json: async () => defaultServiceInfo()
+      };
+    }
     if (!url.endsWith("/synthesize")) {
       throw new Error(`Unhandled mock fetch URL: ${url}`);
     }
@@ -283,7 +300,7 @@ test.serial("prefetch requests are chained: never more than one /synthesize in f
     };
   }) as unknown as typeof fetch;
 
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl, prefetchWindow: 3 });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl, prefetchWindow: 3 });
   engine.loadUtterances([{ plain: "One" }, { plain: "Two" }, { plain: "Three" }, { plain: "Four" }]);
 
   engine.speak(0);
@@ -307,7 +324,7 @@ test.serial("a completed prefetch is reused instead of triggering a second fetch
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "First." }, { plain: "Second." }]);
 
   engine.speak(0);
@@ -323,7 +340,7 @@ test.serial("changing rate invalidates a pending prefetch", async (t) => {
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "First." }, { plain: "Second." }]);
 
   engine.speak(0);
@@ -343,7 +360,7 @@ test.serial("no prefetch happens past the end of the queue", async (t) => {
   const { fetchImpl, calls } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "Only one." }]);
 
   engine.speak(0);
@@ -356,7 +373,7 @@ test.serial("stop() resets to idle and index 0", async (t) => {
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "One" }, { plain: "Two" }]);
   engine.speak(1);
   await flush();
@@ -380,7 +397,7 @@ test.serial("a non-ok /synthesize response surfaces as an error event, not a thr
       contentType: "application/problem+json"
     })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "Hello" }]);
 
   const errors: any[] = [];
@@ -400,7 +417,7 @@ test.serial("rate is only faked locally when the voice's controls don't report s
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.setRate(2);
   engine.loadUtterances([{ plain: "Hello" }]);
 
@@ -419,11 +436,257 @@ test.serial("setVolume applies to the live audio element", async (t) => {
   const { fetchImpl } = createMockFetch({
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
-  const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   engine.loadUtterances([{ plain: "Hello" }]);
   engine.speak();
   await flush();
 
   engine.setVolume(0.4);
   t.is(MockAudio.instances[0].volume, 0.4);
+});
+
+test.serial("synthesize() requests /service's advertised default output format", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    // A single advertised format means it's the only playable candidate regardless of
+    // strategy, isolating this test from selectFormat()'s quality/bandwidth ranking.
+    service: () => ({ json: { ...defaultServiceInfo(), output: { formats: ["mp3"], default: "mp3" } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "mp3", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
+  t.is(body.output.format, "mp3");
+});
+
+test.serial("/service is only fetched once and reused across multiple synthesize() calls", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.loadUtterances([{ plain: "First." }, { plain: "Second." }]);
+
+  engine.speak(0);
+  await flush();
+  engine.speak(1);
+  await flush();
+
+  t.is(calls.filter(c => c.url.endsWith("/service")).length, 1, "cached after the first fetch");
+});
+
+test.serial("text exceeding /service's maxTextLength is split into multiple sequential /synthesize requests by default", async (t) => {
+  const maxTextLength = 20;
+  const text = "First sentence here now. Second sentence follows too.";
+  const expectedChunks = chunkPlainText(text, maxTextLength);
+  t.true(expectedChunks.length > 1, "test text must actually need chunking for this test to be meaningful");
+
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength, maxConcurrentSyntheses: 2 } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.loadUtterances([{ plain: text }]);
+
+  engine.speak();
+  await flush();
+
+  const synthCalls = calls.filter(c => c.url.endsWith("/synthesize"));
+  t.is(synthCalls.length, expectedChunks.length);
+  t.deepEqual(synthCalls.map(c => JSON.parse(c.init.body).text), expectedChunks.map(c => c.text));
+});
+
+test.serial("chunked utterance playback fires a single start/end pair across all chunks, chained via onended", async (t) => {
+  const maxTextLength = 20;
+  const text = "First sentence here now. Second sentence follows too.";
+  const expectedChunkCount = chunkPlainText(text, maxTextLength).length;
+  t.true(expectedChunkCount > 1);
+
+  const { fetchImpl } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength, maxConcurrentSyntheses: 2 } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.loadUtterances([{ plain: text }]);
+
+  const events: string[] = [];
+  engine.on("start", () => events.push("start"));
+  engine.on("end", () => events.push("end"));
+
+  engine.speak();
+  await flush();
+
+  t.is(MockAudio.instances.length, 1, "only the first chunk's <audio> exists until it ends — the rest are created lazily");
+  t.deepEqual(events, ["start"], "\"start\" fires once, for the logical utterance, not per chunk");
+
+  for (let i = 0; i < expectedChunkCount - 1; i++) {
+    MockAudio.instances[i].onended?.();
+    t.is(MockAudio.instances.length, i + 2, "the next chunk's <audio> is created once the previous one ends");
+    t.deepEqual(events, ["start"], "\"end\" hasn't fired yet — chunks before the last just chain to the next");
+  }
+
+  MockAudio.instances[expectedChunkCount - 1].onended?.();
+  t.is(MockAudio.instances.length, expectedChunkCount, "exactly one <audio> element was created per chunk overall");
+  t.deepEqual(events, ["start", "end"], "\"end\" fires once, only after the last chunk");
+  t.is(engine.getState(), "idle");
+});
+
+test.serial("boundary charIndex is offset by each chunk's position in the original utterance text", async (t) => {
+  const maxTextLength = 20;
+  const text = "First sentence here now. Second sentence follows too.";
+  const expectedChunks = chunkPlainText(text, maxTextLength);
+  t.true(expectedChunks.length > 1);
+
+  const marksByChunkText = new Map(expectedChunks.map(c => [c.text, [{ name: "word", charIndex: 2, charLength: 3, elapsedTime: 0 }]]));
+
+  const { fetchImpl } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength, maxConcurrentSyntheses: 2 } } }),
+    synthesize: (body) => ({ json: { audio: wavBase64(), format: "wav", boundaries: marksByChunkText.get(body.text) ?? null } })
+  });
+  const engine = new SpeechServerEngine({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
+  engine.loadUtterances([{ plain: text }]);
+
+  const boundaries: any[] = [];
+  engine.on("boundary", (e: any) => boundaries.push(e.detail));
+
+  engine.speak();
+  await flush();
+
+  MockAudio.instances[0].currentTime = 0;
+  MockAudio.instances[0].emitTimeUpdate();
+  t.is(boundaries.length, 1);
+  t.is(boundaries[0].charIndex, 2 + expectedChunks[0].offset, "first chunk's charIndex is offset by its (zero) position");
+
+  MockAudio.instances[0].onended?.();
+  MockAudio.instances[1].currentTime = 0;
+  MockAudio.instances[1].emitTimeUpdate();
+  t.is(boundaries.length, 2);
+  t.true(expectedChunks[1].offset > 0, "test setup sanity check: the second chunk isn't at the start of the text");
+  t.is(boundaries[1].charIndex, 2 + expectedChunks[1].offset, "second chunk's charIndex is offset by its position in the original text");
+});
+
+test.serial("overLengthText: \"error\" opts back into the old fail-fast behavior instead of splitting", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength: 5, maxConcurrentSyntheses: 2 } } })
+  });
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    overLengthText: "error"
+  });
+  engine.loadUtterances([{ plain: "Way too long for the limit" }]);
+
+  const errors: any[] = [];
+  engine.on("error", (e: any) => errors.push(e.detail));
+
+  engine.speak();
+  await flush();
+
+  t.is(errors.length, 1);
+  t.is(errors[0].status, 413);
+  t.is(errors[0].type, "https://readium.org/speech-server/error#payload_too_large");
+  t.is(calls.filter(c => c.url.endsWith("/synthesize")).length, 0, "the oversized request never reached /synthesize");
+});
+
+test.serial("overLengthText: \"error\" also rejects over-long SSML content, which isn't split", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength: 5, maxConcurrentSyntheses: 2 } } })
+  });
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    overLengthText: "error"
+  });
+  engine.loadUtterances([{ ssml: "<p>Way too long for the limit</p>" }]);
+
+  const errors: any[] = [];
+  engine.on("error", (e: any) => errors.push(e.detail));
+
+  engine.speak();
+  await flush();
+
+  t.is(errors.length, 1);
+  t.is(errors[0].status, 413);
+  t.is(calls.filter(c => c.url.endsWith("/synthesize")).length, 0);
+});
+
+test.serial("format.preferredFormat is requested when the server advertises it", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), output: { formats: ["wav", "mp3", "opus"], default: "wav" } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "opus", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    format: { preferredFormat: "opus" }
+  });
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
+  t.is(body.output.format, "opus");
+});
+
+test.serial("format.strategy: \"bandwidth\" picks opus over wav/mp3 when all are advertised", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), output: { formats: ["wav", "mp3", "opus"], default: "wav" } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "opus", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    format: { strategy: "bandwidth" }
+  });
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
+  t.is(body.output.format, "opus");
+});
+
+test.serial("no format options sends no bitrate, matching today's behavior", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl
+  });
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  engine.speak();
+  await flush();
+
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
+  t.is(body.output.bitrate, undefined);
+});
+
+test.serial("format.adaptBitrateToNetwork sends a reduced bitrate when navigator.connection reports a constrained connection", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), output: { formats: ["mp3"], default: "mp3" } } }),
+    synthesize: () => ({ json: { audio: wavBase64(), format: "mp3", boundaries: null } })
+  });
+  const engine = new SpeechServerEngine({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    format: { adaptBitrateToNetwork: true }
+  });
+  engine.loadUtterances([{ plain: "Hello" }]);
+
+  (navigator as any).connection = { saveData: true };
+  try {
+    engine.speak();
+    await flush();
+  } finally {
+    delete (navigator as any).connection;
+  }
+
+  const body = JSON.parse(calls.find(c => c.url.endsWith("/synthesize"))!.init.body);
+  t.is(body.output.bitrate, 48000);
 });

--- a/test/SpeechServer/speechServerEngine.test.ts
+++ b/test/SpeechServer/speechServerEngine.test.ts
@@ -82,7 +82,7 @@ test.serial("speak() sends the queue's neighboring utterances as prev_utterance/
   engine.speak(1);
   await flush();
 
-  const body = JSON.parse(calls[0].init.body);
+  const body = JSON.parse(calls.find(c => JSON.parse(c.init.body).text === "Second.")!.init.body);
   t.is(body.text, "Second.");
   t.is(body.prev_utterance, "First.");
   t.is(body.next_utterance, "Third.");
@@ -166,12 +166,16 @@ test.serial("speak() plays audio and fires loading/start/end events", async (t) 
     synthesize: () => ({ json: { audio: wavBase64(), format: "wav", boundaries: null } })
   });
   const engine = new SpeechServerEngine({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
-  engine.loadUtterances([{ plain: "Hello" }]);
 
   const events: string[] = [];
   engine.on("loading", () => events.push("loading"));
   engine.on("start", () => events.push("start"));
   engine.on("end", () => events.push("end"));
+
+  engine.loadUtterances([{ plain: "Hello" }]);
+  await flush();
+  t.is(engine.getState(), "ready", "buffering resolves before playback is requested");
+  events.length = 0; // drop the "loading" from initial buffering; only speak()'s own events matter here
 
   engine.speak();
   await flush();

--- a/test/SpeechServer/speechServerEngineProvider.test.ts
+++ b/test/SpeechServer/speechServerEngineProvider.test.ts
@@ -1,0 +1,68 @@
+import test from "ava";
+import { SpeechServerEngineProvider } from "../../build/index.js";
+import { createMockFetch, makeServerVoice, problemDetails } from "./testUtils.js";
+
+test("getVoices maps server voices into ReadiumSpeechVoice shape and caches", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    voices: () => [
+      makeServerVoice(),
+      makeServerVoice({
+        name: "Estelle",
+        originalName: "estelle",
+        identifier: "urn:readium:tts:pocket:estelle",
+        controls: { speed: true }
+      })
+    ]
+  });
+  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+
+  const voices = await provider.getVoices();
+  t.is(voices.length, 2);
+  t.is(voices[0].source, "server");
+  t.is(voices[0].identifier, "urn:readium:tts:pocket:alba");
+  t.is(voices[0].provider, "pocket");
+  t.deepEqual(voices[1].controls, { speed: true });
+
+  await provider.getVoices();
+  t.is(calls.filter(c => c.url.endsWith("/voices")).length, 1, "second call is served from cache, not refetched");
+});
+
+test("getVoices throws a SpeechServerError carrying the server's problem details on a non-ok response", async (t) => {
+  const { fetchImpl } = createMockFetch({
+    voices: () => ({
+      status: 404,
+      ok: false,
+      json: problemDetails({ detail: "No voices installed." }),
+      contentType: "application/problem+json"
+    })
+  });
+  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+
+  const error = await t.throwsAsync(() => provider.getVoices());
+  t.is((error as any).status, 404);
+  t.is((error as any).message, "No voices installed.");
+});
+
+test("createEngine seeds the engine's voice cache from an already-fetched voice list, without refetching", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    voices: () => [makeServerVoice()]
+  });
+  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  await provider.getVoices();
+
+  const engine = await provider.createEngine("urn:readium:tts:pocket:alba");
+  const voices = await engine.getAvailableVoices();
+
+  t.is(voices.length, 1);
+  t.is(calls.filter(c => c.url.endsWith("/voices")).length, 1, "engine reused the provider's cached voices");
+  t.is(engine.getCurrentVoice()?.identifier, "urn:readium:tts:pocket:alba");
+});
+
+test("createEngine without a prior getVoices call still lets the engine fetch its own voices lazily", async (t) => {
+  const { fetchImpl } = createMockFetch({ voices: () => [makeServerVoice()] });
+  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+
+  const engine = await provider.createEngine();
+  const voices = await engine.getAvailableVoices();
+  t.is(voices.length, 1);
+});

--- a/test/SpeechServer/speechServerEngineProvider.test.ts
+++ b/test/SpeechServer/speechServerEngineProvider.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 import { SpeechServerEngineProvider } from "../../build/index.js";
-import { createMockFetch, makeServerVoice, problemDetails } from "./testUtils.js";
+import { createMockFetch, makeServerVoice, problemDetails, defaultServiceInfo } from "./testUtils.js";
 
 test("getVoices maps server voices into ReadiumSpeechVoice shape and caches", async (t) => {
   const { fetchImpl, calls } = createMockFetch({
@@ -14,7 +14,7 @@ test("getVoices maps server voices into ReadiumSpeechVoice shape and caches", as
       })
     ]
   });
-  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const provider = new SpeechServerEngineProvider({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
 
   const voices = await provider.getVoices();
   t.is(voices.length, 2);
@@ -36,7 +36,7 @@ test("getVoices throws a SpeechServerError carrying the server's problem details
       contentType: "application/problem+json"
     })
   });
-  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const provider = new SpeechServerEngineProvider({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
 
   const error = await t.throwsAsync(() => provider.getVoices());
   t.is((error as any).status, 404);
@@ -47,7 +47,7 @@ test("createEngine seeds the engine's voice cache from an already-fetched voice 
   const { fetchImpl, calls } = createMockFetch({
     voices: () => [makeServerVoice()]
   });
-  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const provider = new SpeechServerEngineProvider({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
   await provider.getVoices();
 
   const engine = await provider.createEngine("urn:readium:tts:pocket:alba");
@@ -60,9 +60,34 @@ test("createEngine seeds the engine's voice cache from an already-fetched voice 
 
 test("createEngine without a prior getVoices call still lets the engine fetch its own voices lazily", async (t) => {
   const { fetchImpl } = createMockFetch({ voices: () => [makeServerVoice()] });
-  const provider = new SpeechServerEngineProvider({ baseUrl: "http://localhost:8000", fetch: fetchImpl });
+  const provider = new SpeechServerEngineProvider({ endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" }, fetch: fetchImpl });
 
   const engine = await provider.createEngine();
   const voices = await engine.getAvailableVoices();
   t.is(voices.length, 1);
+});
+
+test("createEngine forwards overLengthText/format/readyBufferChars to the engine it creates, not just endpoints/fetch/prefetchWindow", async (t) => {
+  const { fetchImpl, calls } = createMockFetch({
+    service: () => ({ json: { ...defaultServiceInfo(), limits: { maxTextLength: 5, maxConcurrentSyntheses: 2 } } })
+  });
+  const provider = new SpeechServerEngineProvider({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl,
+    overLengthText: "error"
+  });
+
+  const engine = await provider.createEngine();
+  engine.loadUtterances([{ plain: "Way too long for the limit" }]);
+
+  const errors: any[] = [];
+  engine.on("error", (e: any) => errors.push(e.detail));
+
+  engine.speak();
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  t.is(errors.length, 1, "the provider's overLengthText: \"error\" reached the engine, instead of silently defaulting to \"split\"");
+  t.is(errors[0].status, 413);
+  t.is(calls.filter(c => c.url.endsWith("/synthesize")).length, 0);
 });

--- a/test/SpeechServer/testUtils.ts
+++ b/test/SpeechServer/testUtils.ts
@@ -1,0 +1,92 @@
+// Shared mock-fetch helper for SpeechServer tests. Mimics only what
+// SpeechServerEngine/SpeechServerEngineProvider actually call on a Response:
+// `.ok`, `.status`, `.headers.get(...)`, `.json()`.
+
+export interface MockFetchCall {
+  url: string;
+  init?: any;
+}
+
+export interface MockFetchResult {
+  status?: number;
+  ok?: boolean;
+  json: any;
+  contentType?: string;
+}
+
+export interface MockFetchHandlers {
+  voices?: () => any[] | MockFetchResult;
+  synthesize?: (body: any) => MockFetchResult;
+}
+
+function mockResponse(status: number, ok: boolean, data: any, contentType: string) {
+  return {
+    ok,
+    status,
+    headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null) },
+    json: async () => data
+  };
+}
+
+export function createMockFetch(handlers: MockFetchHandlers) {
+  const calls: MockFetchCall[] = [];
+
+  const fetchImpl = (async (url: string, init?: any) => {
+    calls.push({ url, init });
+
+    if (url.endsWith("/voices")) {
+      const result = handlers.voices ? handlers.voices() : [];
+      if (Array.isArray(result)) {
+        return mockResponse(200, true, result, "application/json");
+      }
+      return mockResponse(result.status ?? 200, result.ok ?? true, result.json, result.contentType ?? "application/json");
+    }
+
+    if (url.endsWith("/synthesize")) {
+      const body = init?.body ? JSON.parse(init.body) : {};
+      const result: MockFetchResult = handlers.synthesize
+        ? handlers.synthesize(body)
+        : { json: { audio: "", format: "wav", boundaries: null } };
+      return mockResponse(result.status ?? 200, result.ok ?? true, result.json, result.contentType ?? "application/json");
+    }
+
+    throw new Error(`Unhandled mock fetch URL: ${url}`);
+  }) as unknown as typeof fetch;
+
+  return { fetchImpl, calls };
+}
+
+export function makeServerVoice(overrides: Record<string, any> = {}) {
+  return {
+    name: "Alba",
+    originalName: "alba",
+    provider: "pocket",
+    identifier: "urn:readium:tts:pocket:alba",
+    language: "en-US",
+    otherLanguages: [],
+    gender: "female",
+    quality: "veryHigh",
+    controls: {},
+    ...overrides
+  };
+}
+
+export function problemDetails(overrides: Record<string, any> = {}) {
+  return {
+    type: "https://readium.org/speech-server/error#voice_not_found",
+    title: "Voice Not Found",
+    status: 404,
+    detail: "Voice not found.",
+    instance: "urn:uuid:test",
+    ...overrides
+  };
+}
+
+export function wavBase64(): string {
+  return Buffer.from("RIFF-fake-wav-bytes").toString("base64");
+}
+
+export async function flush(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 0));
+}

--- a/test/SpeechServer/testUtils.ts
+++ b/test/SpeechServer/testUtils.ts
@@ -73,7 +73,7 @@ export function makeServerVoice(overrides: Record<string, any> = {}) {
 
 export function problemDetails(overrides: Record<string, any> = {}) {
   return {
-    type: "https://readium.org/speech-server/error#voice_not_found",
+    type: "urn:example:voice-not-found",
     title: "Voice Not Found",
     status: 404,
     detail: "Voice not found.",

--- a/test/SpeechServer/testUtils.ts
+++ b/test/SpeechServer/testUtils.ts
@@ -17,6 +17,15 @@ export interface MockFetchResult {
 export interface MockFetchHandlers {
   voices?: () => any[] | MockFetchResult;
   synthesize?: (body: any) => MockFetchResult;
+  service?: () => MockFetchResult;
+}
+
+export function defaultServiceInfo() {
+  return {
+    output: { formats: ["wav", "mp3", "opus"], default: "wav" },
+    limits: { maxTextLength: 2000, maxConcurrentSyntheses: 2 },
+    providers: [{ id: "pocket", installedLanguages: ["en"] }]
+  };
 }
 
 function mockResponse(status: number, ok: boolean, data: any, contentType: string) {
@@ -47,6 +56,11 @@ export function createMockFetch(handlers: MockFetchHandlers) {
       const result: MockFetchResult = handlers.synthesize
         ? handlers.synthesize(body)
         : { json: { audio: "", format: "wav", boundaries: null } };
+      return mockResponse(result.status ?? 200, result.ok ?? true, result.json, result.contentType ?? "application/json");
+    }
+
+    if (url.endsWith("/service")) {
+      const result: MockFetchResult = handlers.service ? handlers.service() : { json: defaultServiceInfo() };
       return mockResponse(result.status ?? 200, result.ok ?? true, result.json, result.contentType ?? "application/json");
     }
 

--- a/test/providerRegistry/providerRegistry.test.ts
+++ b/test/providerRegistry/providerRegistry.test.ts
@@ -1,0 +1,116 @@
+import test from "ava";
+import {
+  ReadiumSpeechProviderRegistry,
+  WebSpeechEngineProvider,
+  SpeechServerEngineProvider,
+  WebSpeechVoiceManager
+} from "../../build/index.js";
+import { createMockFetch, makeServerVoice } from "../SpeechServer/testUtils.js";
+
+// =============================================
+// Mock Web Speech API
+// =============================================
+// WebSpeechEngineProvider constructs a WebSpeechEngine internally, which throws
+// in its constructor unless speechSynthesis/SpeechSynthesisUtterance exist.
+
+class MockUtterance {
+  constructor(public text: string) {}
+}
+
+function makeVoice(lang: string, name: string) {
+  return { voiceURI: `${name}-${lang}`, name, lang, localService: true, default: false };
+}
+
+const mockWebSpeechVoices = [makeVoice("en-US", "English Voice")];
+
+function setWebSpeechGlobals() {
+  if (typeof (globalThis as any).window === "undefined") {
+    (globalThis as any).window = globalThis;
+  }
+  (globalThis as any).window.SpeechSynthesisUtterance = MockUtterance;
+  (globalThis as any).window.speechSynthesis = {
+    speaking: false,
+    paused: false,
+    onvoiceschanged: null,
+    getVoices: () => mockWebSpeechVoices,
+    speak: () => {},
+    cancel: () => {},
+    pause: () => {},
+    resume: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  };
+}
+
+test.beforeEach(() => {
+  (WebSpeechVoiceManager as any).instance = undefined;
+  (WebSpeechVoiceManager as any).initializationPromise = null;
+  setWebSpeechGlobals();
+});
+
+test.afterEach.always(() => {
+  (WebSpeechVoiceManager as any).instance = undefined;
+  (WebSpeechVoiceManager as any).initializationPromise = null;
+});
+
+function makeSpeechServerProvider() {
+  const { fetchImpl } = createMockFetch({ voices: () => [makeServerVoice()] });
+  return new SpeechServerEngineProvider({
+    endpoints: { voices: "http://localhost:8000/voices", synthesize: "http://localhost:8000/synthesize", service: "http://localhost:8000/service" },
+    fetch: fetchImpl
+  });
+}
+
+// =============================================
+// Tests
+// =============================================
+
+test.serial("getAllVoices() returns grouped voices for every registered provider, including WebSpeech with no engine created yet", async (t) => {
+  const registry = new ReadiumSpeechProviderRegistry();
+  registry.register(new WebSpeechEngineProvider());
+  registry.register(makeSpeechServerProvider());
+
+  const grouped = await registry.getAllVoices();
+
+  const webspeech = grouped.find(g => g.providerId === "webspeech");
+  const speechServer = grouped.find(g => g.providerId === "speech-server");
+
+  t.truthy(webspeech, "webspeech group is present");
+  t.true(webspeech!.voices.length > 0, "WebSpeechEngineProvider.getVoices() resolves without requiring createEngine() first");
+  t.truthy(speechServer);
+  t.true(speechServer!.voices.length > 0);
+});
+
+function registerBoth(registry: ReadiumSpeechProviderRegistry): void {
+  registry.register(new WebSpeechEngineProvider());
+  registry.register(makeSpeechServerProvider());
+}
+
+for (const providerId of ["webspeech", "speech-server"]) {
+  test.serial(`getVoices("${providerId}") works on its own, without createEngine() or getAllVoices() first`, async (t) => {
+    const registry = new ReadiumSpeechProviderRegistry();
+    registerBoth(registry);
+
+    const voices = await registry.getVoices(providerId);
+    t.true(voices.length > 0);
+  });
+
+  test.serial(`createEngine("${providerId}") works for a provider whose voices were never explicitly fetched via getVoices()`, async (t) => {
+    const registry = new ReadiumSpeechProviderRegistry();
+    registerBoth(registry);
+
+    const engine = await registry.createEngine(providerId);
+    t.truthy(engine);
+  });
+}
+
+test.serial("destroy() tears down every registered provider and clears the registry", async (t) => {
+  const registry = new ReadiumSpeechProviderRegistry();
+  registry.register(new WebSpeechEngineProvider());
+  registry.register(makeSpeechServerProvider());
+
+  await registry.getAllVoices();
+  await registry.destroy();
+
+  t.deepEqual(registry.list(), []);
+});


### PR DESCRIPTION
This adds the missing pieces for speech-server i.e. an engine, its provider, and support in the playback Navigator. 

Note a provider registry is also committed so that it is easier to retrieve all voices from all sources (WebSpeech, server). 

Server engine is currently trying to aggressively prefetch audio files in order to have utterances ready as soon as possible. But long utterances are still a significant challenge, with noticeable time elapsing between two utterances at times. 