### PR TITLE
Preferences adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [0.7.0] - 2026-08-04
 
+### Added
+
+- `autoPause` preference (`"none" | "utterance" | "block"`, default `"none"`) — fully pauses playback between utterances or blocks (fires `pause`, `navigator.getState()` becomes `"paused"`) instead of continuing on its own; playback resumes only when `play()` is called. See [Preferences.md](docs/Preferences.md#prosody).
+
 ### Changed
 
 - `SpeechDefaults.language` default is now `"block-level"`, was `"always"`.
-- `ReadiumSpeechUtterance` drops `startsNewBlock`. Block-boundary info is now internal to extraction — `pauseScope: "block"` only has effect on content loaded via `loadGndContent()`; content loaded via `loadContent()` never gets a pause under it.
+- `ReadiumSpeechUtterance` drops `startsNewBlock`. Block-boundary info is now internal to extraction — `autoPause: "block"` only has effect on content loaded via `loadGndContent()`; content loaded via `loadContent()` never triggers it.
+- `pauseDuration` always delays the next automatic continuation now that `pauseScope` is gone — it's no longer scoped to a subset of transitions.
+
+### Removed
+
+- `SpeechPreferences.pauseScope` / `SpeechDefaults.pauseScope`, added in 0.6.0. It was meant to implement automatic pausing between utterances/paragraphs but only ever delayed an automatic continuation rather than actually pausing — replaced by `autoPause`.
 
 ## [0.6.0] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows [Semantic Versioning](https://semver.org/).
 
+## [0.7.0] - 2026-08-04
+
+### Changed
+
+- `SpeechDefaults.language` default is now `"block-level"`, was `"always"`.
+- `ReadiumSpeechUtterance` drops `startsNewBlock`. Block-boundary info is now internal to extraction — `pauseScope: "block"` only has effect on content loaded via `loadGndContent()`; content loaded via `loadContent()` never gets a pause under it.
+
 ## [0.6.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ In the third phase, we added highlighting: content currently being spoken (e.g. 
 
 In the fourth phase, we extracted [Guided Navigation objects](https://readium.org/guided-navigation) from a document (or a fragment of a document), and generated utterances from these objects.
 
-We are now on the fifth phase: a second `ReadiumSpeechPlaybackEngine` implementation, backed by [speech-server](https://github.com/readium/speech-server) instead of the browser's Web Speech API.
+In the fifth phase, we added a second `ReadiumSpeechPlaybackEngine` implementation, backed by [speech-server](https://github.com/readium/speech-server) instead of the browser's Web Speech API.
+
+We are now on the sixth phase: verbosity and prosody, in particular contextualization — synthesized announcements spoken around content based on its role (entering/leaving a chapter, a footnote, a pagebreak…). See [Preferences](docs/Preferences.md).
 
 ## Demos
 

--- a/demo/playground/index.html
+++ b/demo/playground/index.html
@@ -121,10 +121,10 @@
           </div>
           <div class="field">
             <label>
-              <span class="field-caption">pauseScope</span>
-              <select id="option-pause-scope"></select>
+              <span class="field-caption">autoPause</span>
+              <select id="option-auto-pause"></select>
             </label>
-            <small class="default-hint" id="pause-scope-hint"></small>
+            <small class="default-hint" id="auto-pause-hint"></small>
           </div>
           <div class="field">
             <label>

--- a/demo/playground/script.js
+++ b/demo/playground/script.js
@@ -15,7 +15,7 @@ const optionInterruptEl = document.getElementById("option-interrupt");
 const optionContextualizeEl = document.getElementById("option-contextualize");
 const optionPauseDurationEl = document.getElementById("option-pause-duration");
 const optionPauseDurationValueEl = document.getElementById("option-pause-duration-value");
-const optionPauseScopeEl = document.getElementById("option-pause-scope");
+const optionAutoPauseEl = document.getElementById("option-auto-pause");
 const optionRateEl = document.getElementById("option-rate");
 const optionRateValueEl = document.getElementById("option-rate-value");
 const optionPitchEl = document.getElementById("option-pitch");
@@ -28,7 +28,7 @@ const languageHintEl = document.getElementById("language-hint");
 const verbosityHintEl = document.getElementById("verbosity-hint");
 const inlineContextualizationHintEl = document.getElementById("inline-contextualization-hint");
 const pauseDurationHintEl = document.getElementById("pause-duration-hint");
-const pauseScopeHintEl = document.getElementById("pause-scope-hint");
+const autoPauseHintEl = document.getElementById("auto-pause-hint");
 const rateHintEl = document.getElementById("rate-hint");
 const pitchHintEl = document.getElementById("pitch-hint");
 const volumeHintEl = document.getElementById("volume-hint");
@@ -179,7 +179,7 @@ function renderToolbarOptions() {
 
   populateEnumSelect(optionLanguageEl, editor.language.supportedValues, { includeDefaultOption: true });
   populateEnumSelect(optionVerbosityEl, editor.verbosity.supportedValues);
-  populateEnumSelect(optionPauseScopeEl, editor.pauseScope.supportedValues);
+  populateEnumSelect(optionAutoPauseEl, editor.autoPause.supportedValues);
 
   for (const { key, inputEl } of rangeControls) {
     const [min, max] = editor[key].supportedRange;
@@ -232,8 +232,8 @@ function renderToolbarState() {
     valueEl.textContent = `${inputEl.value}${unit}`;
   }
 
-  setDefaultLabel(pauseScopeHintEl, libraryDefaults?.pauseScope);
-  optionPauseScopeEl.value = editor.pauseScope.value ?? editor.pauseScope.effectiveValue;
+  setDefaultLabel(autoPauseHintEl, libraryDefaults?.autoPause);
+  optionAutoPauseEl.value = editor.autoPause.value ?? editor.autoPause.effectiveValue;
 }
 
 function setDefaultLabel(hintEl, defaultValue) {
@@ -250,7 +250,7 @@ function applyPreferencesFromToolbar() {
   editor.inlineContextualization.value = optionInterruptEl?.checked ?? false;
   editor.verbosity.value = optionVerbosityEl?.value || "few";
   editor.language.value = optionLanguageEl?.value || null;
-  editor.pauseScope.value = optionPauseScopeEl?.value || "utterance";
+  editor.autoPause.value = optionAutoPauseEl?.value || "none";
   for (const { key, inputEl } of rangeControls) {
     editor[key].value = Number(inputEl.value);
   }
@@ -283,7 +283,7 @@ function resetProsodyPreferences() {
   if (!configurable) return;
   const editor = configurable.preferencesEditor;
   for (const { key } of rangeControls) editor[key].clear();
-  editor.pauseScope.clear();
+  editor.autoPause.clear();
   configurable.submitPreferences(editor.preferences);
   renderToolbarState();
   renderUtterancesPanel();
@@ -754,7 +754,7 @@ for (const { inputEl, valueEl, unit } of rangeControls) {
   });
   inputEl.addEventListener("change", applyPreferencesFromToolbar);
 }
-optionPauseScopeEl?.addEventListener("change", applyPreferencesFromToolbar);
+optionAutoPauseEl?.addEventListener("change", applyPreferencesFromToolbar);
 resetExtractionPreferencesEl?.addEventListener("click", resetExtractionPreferences);
 resetProsodyPreferencesEl?.addEventListener("click", resetProsodyPreferences);
 

--- a/demo/playground/styles.css
+++ b/demo/playground/styles.css
@@ -372,7 +372,7 @@ body {
 }
 
 /* Marks where extractUtterances() detected a block boundary — the point
-   pauseDuration lands on under pauseScope: "block". */
+   autoPause: "block" triggers on. */
 .speech-utterances li.starts-new-block {
   border-top: 2px solid #999;
   margin-top: 6px;

--- a/docs/Preferences.md
+++ b/docs/Preferences.md
@@ -12,7 +12,7 @@ editor.pauseDuration.value = 500;
 navigator.submitPreferences(editor.preferences);
 ```
 
-`submitPreferences()` always resolves `navigator.settings`. Prosody (`pauseDuration`, `pauseScope`, `rate`, `pitch`, `volume`) applies regardless of how content was loaded, except that `pauseScope: "block"` only has block boundaries to work with on content loaded via `loadGndContent()` — content loaded via `loadContent()` has none, so no transition ever gets `pauseDuration` there. The extraction group (`format`, `inlineContextualization`, `verbosity`, `skip`, `contextualize`, `language`) only takes effect on content loaded via `loadGndContent()` — see [Playback](Playback.md) — and only reloads the queue when one of those fields actually changes value. A reload during playback resumes at the same content rather than restarting, falling back to the nearest earlier point still present if that exact content got skipped by the new settings.
+`submitPreferences()` always resolves `navigator.settings`. Prosody (`pauseDuration`, `autoPause`, `rate`, `pitch`, `volume`) applies regardless of how content was loaded, except that `autoPause: "block"` only has block boundaries to work with on content loaded via `loadGndContent()` — content loaded via `loadContent()` has none, so it never triggers there. The extraction group (`format`, `inlineContextualization`, `verbosity`, `skip`, `contextualize`, `language`) only takes effect on content loaded via `loadGndContent()` — see [Playback](Playback.md) — and only reloads the queue when one of those fields actually changes value. A reload during playback resumes at the same content rather than restarting, falling back to the nearest earlier point still present if that exact content got skipped by the new settings.
 
 ## Defaults
 
@@ -48,14 +48,14 @@ new SpeechPreferences({ verbosity: "custom", contextualize: ["chapter", "footnot
 ## Prosody
 
 ```typescript
-pauseDuration?: number;                      // ms, default 300
-pauseScope?: "utterance" | "block";          // which transitions get pauseDuration, default "utterance"
-rate?: number;                               // default 1.0, range [0.1, 10]
-pitch?: number;                              // default 1.0, range [0, 2]
-volume?: number;                             // default 1.0, range [0, 1]
+pauseDuration?: number;                          // ms, default 300
+autoPause?: "none" | "utterance" | "block";      // fully pause instead of continuing automatically, default "none"
+rate?: number;                                   // default 1.0, range [0.1, 10]
+pitch?: number;                                  // default 1.0, range [0, 2]
+volume?: number;                                 // default 1.0, range [0, 1]
 ```
 
-`pauseDuration` delays the navigator's next `speak()` call after each utterance ends, scoped by `pauseScope`: `"utterance"` (the default) applies it between every utterance; `"block"` applies it only where the next utterance starts a new block-level element (a paragraph, heading, list item, table cell, ...).
+`pauseDuration` and `autoPause` are unrelated. `pauseDuration` always delays the navigator's next automatic `speak()` call after an utterance ends — it's just a gap, playback keeps going on its own. `autoPause` decides whether that automatic continuation happens at all: `"none"` (the default) never interrupts it; `"utterance"` stops playback after every utterance; `"block"` stops it only where the next utterance starts a new block-level element (a paragraph, heading, list item, table cell, ...). An auto-pause fires a `pause` event and moves `navigator.getState()` to `"paused"`, exactly like calling `pause()` yourself — nothing plays again until `play()` is called.
 
 `rate`/`pitch`/`volume` are pushed straight to the engine's own `setRate`/`setPitch`/`setVolume` on every `submitPreferences()` call — unlike the extraction-time preferences, no reload. An engine that needs to re-synthesize already-buffered content on parameter changes handles that itself inside those setters.
 

--- a/docs/Preferences.md
+++ b/docs/Preferences.md
@@ -12,7 +12,7 @@ editor.pauseDuration.value = 500;
 navigator.submitPreferences(editor.preferences);
 ```
 
-`submitPreferences()` always resolves `navigator.settings`. Prosody (`pauseDuration`, `pauseScope`, `rate`, `pitch`, `volume`) applies regardless of how content was loaded. The extraction group (`format`, `inlineContextualization`, `verbosity`, `skip`, `contextualize`, `language`) only takes effect on content loaded via `loadGndContent()` — see [Playback](Playback.md) — and only reloads the queue when one of those fields actually changes value. A reload during playback resumes at the same content rather than restarting, falling back to the nearest earlier point still present if that exact content got skipped by the new settings.
+`submitPreferences()` always resolves `navigator.settings`. Prosody (`pauseDuration`, `pauseScope`, `rate`, `pitch`, `volume`) applies regardless of how content was loaded, except that `pauseScope: "block"` only has block boundaries to work with on content loaded via `loadGndContent()` — content loaded via `loadContent()` has none, so no transition ever gets `pauseDuration` there. The extraction group (`format`, `inlineContextualization`, `verbosity`, `skip`, `contextualize`, `language`) only takes effect on content loaded via `loadGndContent()` — see [Playback](Playback.md) — and only reloads the queue when one of those fields actually changes value. A reload during playback resumes at the same content rather than restarting, falling back to the nearest earlier point still present if that exact content got skipped by the new settings.
 
 ## Defaults
 
@@ -50,13 +50,12 @@ new SpeechPreferences({ verbosity: "custom", contextualize: ["chapter", "footnot
 ```typescript
 pauseDuration?: number;                      // ms, default 300
 pauseScope?: "utterance" | "block";          // which transitions get pauseDuration, default "utterance"
-automaticPausesAtPageOrSpreadEnd?: boolean;  // typed, no effect yet
 rate?: number;                               // default 1.0, range [0.1, 10]
 pitch?: number;                              // default 1.0, range [0, 2]
 volume?: number;                             // default 1.0, range [0, 1]
 ```
 
-`pauseDuration` delays the navigator's next `speak()` call after each utterance ends, scoped by `pauseScope`: `"utterance"` (the default) applies it between every utterance; `"block"` applies it only where the next utterance starts a new block-level element (a paragraph, heading, list item, table cell, ...), derived from the source Guided Navigation document by `extractUtterances()` — transitions within the same block get no pause. `automaticPausesAtPageOrSpreadEnd` is typed but has no effect today: pausing at a page/spread boundary needs context (where a page actually ends) that this library doesn't have — likely a concern for the consuming app, not something resolved here.
+`pauseDuration` delays the navigator's next `speak()` call after each utterance ends, scoped by `pauseScope`: `"utterance"` (the default) applies it between every utterance; `"block"` applies it only where the next utterance starts a new block-level element (a paragraph, heading, list item, table cell, ...).
 
 `rate`/`pitch`/`volume` are pushed straight to the engine's own `setRate`/`setPitch`/`setVolume` on every `submitPreferences()` call — unlike the extraction-time preferences, no reload. An engine that needs to re-synthesize already-buffered content on parameter changes handles that itself inside those setters.
 

--- a/docs/UtteranceExtraction.md
+++ b/docs/UtteranceExtraction.md
@@ -18,12 +18,9 @@ interface ReadiumSpeechUtterance {
   id?: string;
   plain?: string;
   ssml?: string;
-  language?: string;      // BCP 47
-  startsNewBlock?: true;  // present (and true) only when this utterance begins a new block-level element
+  language?: string; // BCP 47
 }
 ```
-
-`startsNewBlock` marks the first utterance of a node whose role is in `blockLevelRoles` (a paragraph, heading, list item, table cell, ...) whenever it isn't a continuation of the block already in progress — e.g. a `<p>` split into several utterances by inline `<lang>` spans only gets the marker on its first piece. `ReadiumSpeechNavigator` uses it to scope `pauseDuration` under `pauseScope: "block"` (see [Preferences](Preferences.md#prosody)).
 
 Some roles get a synthesized navigational announcement spoken around their content (entering/leaving a chapter, a pagebreak label...); see [`ExtractUtterancesOptions.announcements`](../src/utterances/types.ts) and [`defaultAnnouncements`](../src/utterances/announcements.ts) in source — the catalog is still English-only and expected to move to a localized (Weblate-sourced) format, so it isn't documented here yet.
 

--- a/fixtures/abstract-epub-type/utterances.json
+++ b/fixtures/abstract-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "This work examines the maintenance of coastal lighthouses in the 19th century.",
-          "startsNewBlock": true
+          "plain": "This work examines the maintenance of coastal lighthouses in the 19th century."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Abstract.",
-          "startsNewBlock": true
+          "plain": "Abstract."
         },
         {
           "plain": "This work examines the maintenance of coastal lighthouses in the 19th century."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This work examines the maintenance of coastal lighthouses in the 19th century.",
-          "startsNewBlock": true
+          "ssml": "This work examines the maintenance of coastal lighthouses in the 19th century."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Abstract.",
-          "startsNewBlock": true
+          "ssml": "Abstract."
         },
         {
           "ssml": "This work examines the maintenance of coastal lighthouses in the 19th century."

--- a/fixtures/abstract-role-aria/utterances.json
+++ b/fixtures/abstract-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "This work examines the maintenance of coastal lighthouses in the 19th century.",
-          "startsNewBlock": true
+          "plain": "This work examines the maintenance of coastal lighthouses in the 19th century."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Abstract.",
-          "startsNewBlock": true
+          "plain": "Abstract."
         },
         {
           "plain": "This work examines the maintenance of coastal lighthouses in the 19th century."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This work examines the maintenance of coastal lighthouses in the 19th century.",
-          "startsNewBlock": true
+          "ssml": "This work examines the maintenance of coastal lighthouses in the 19th century."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Abstract.",
-          "startsNewBlock": true
+          "ssml": "Abstract."
         },
         {
           "ssml": "This work examines the maintenance of coastal lighthouses in the 19th century."

--- a/fixtures/acknowledgments-epub-type/utterances.json
+++ b/fixtures/acknowledgments-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "The author thanks the keepers of Fastnet Rock for their recollections.",
-          "startsNewBlock": true
+          "plain": "The author thanks the keepers of Fastnet Rock for their recollections."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the acknowledgments.",
-          "startsNewBlock": true
+          "plain": "Start of the acknowledgments."
         },
         {
           "plain": "The author thanks the keepers of Fastnet Rock for their recollections."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "The author thanks the keepers of Fastnet Rock for their recollections.",
-          "startsNewBlock": true
+          "ssml": "The author thanks the keepers of Fastnet Rock for their recollections."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the acknowledgments.",
-          "startsNewBlock": true
+          "ssml": "Start of the acknowledgments."
         },
         {
           "ssml": "The author thanks the keepers of Fastnet Rock for their recollections."

--- a/fixtures/acknowledgments-role-aria/utterances.json
+++ b/fixtures/acknowledgments-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "The author thanks the keepers of Fastnet Rock for their recollections.",
-          "startsNewBlock": true
+          "plain": "The author thanks the keepers of Fastnet Rock for their recollections."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the acknowledgments.",
-          "startsNewBlock": true
+          "plain": "Start of the acknowledgments."
         },
         {
           "plain": "The author thanks the keepers of Fastnet Rock for their recollections."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "The author thanks the keepers of Fastnet Rock for their recollections.",
-          "startsNewBlock": true
+          "ssml": "The author thanks the keepers of Fastnet Rock for their recollections."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the acknowledgments.",
-          "startsNewBlock": true
+          "ssml": "Start of the acknowledgments."
         },
         {
           "ssml": "The author thanks the keepers of Fastnet Rock for their recollections."

--- a/fixtures/afterword-epub-type/utterances.json
+++ b/fixtures/afterword-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Years later, the last lighthouse keeper reflects on automation.",
-          "startsNewBlock": true
+          "plain": "Years later, the last lighthouse keeper reflects on automation."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the afterword.",
-          "startsNewBlock": true
+          "plain": "Start of the afterword."
         },
         {
           "plain": "Years later, the last lighthouse keeper reflects on automation."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Years later, the last lighthouse keeper reflects on automation.",
-          "startsNewBlock": true
+          "ssml": "Years later, the last lighthouse keeper reflects on automation."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the afterword.",
-          "startsNewBlock": true
+          "ssml": "Start of the afterword."
         },
         {
           "ssml": "Years later, the last lighthouse keeper reflects on automation."

--- a/fixtures/afterword-role-aria/utterances.json
+++ b/fixtures/afterword-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Years later, the last lighthouse keeper reflects on automation.",
-          "startsNewBlock": true
+          "plain": "Years later, the last lighthouse keeper reflects on automation."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the afterword.",
-          "startsNewBlock": true
+          "plain": "Start of the afterword."
         },
         {
           "plain": "Years later, the last lighthouse keeper reflects on automation."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Years later, the last lighthouse keeper reflects on automation.",
-          "startsNewBlock": true
+          "ssml": "Years later, the last lighthouse keeper reflects on automation."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the afterword.",
-          "startsNewBlock": true
+          "ssml": "Start of the afterword."
         },
         {
           "ssml": "Years later, the last lighthouse keeper reflects on automation."

--- a/fixtures/appendix-epub-type/utterances.json
+++ b/fixtures/appendix-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A table of lighthouse construction dates referenced in the text.",
-          "startsNewBlock": true
+          "plain": "A table of lighthouse construction dates referenced in the text."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the appendix.",
-          "startsNewBlock": true
+          "plain": "Start of the appendix."
         },
         {
           "plain": "A table of lighthouse construction dates referenced in the text."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A table of lighthouse construction dates referenced in the text.",
-          "startsNewBlock": true
+          "ssml": "A table of lighthouse construction dates referenced in the text."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the appendix.",
-          "startsNewBlock": true
+          "ssml": "Start of the appendix."
         },
         {
           "ssml": "A table of lighthouse construction dates referenced in the text."

--- a/fixtures/appendix-role-aria/utterances.json
+++ b/fixtures/appendix-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A table of lighthouse construction dates referenced in the text.",
-          "startsNewBlock": true
+          "plain": "A table of lighthouse construction dates referenced in the text."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the appendix.",
-          "startsNewBlock": true
+          "plain": "Start of the appendix."
         },
         {
           "plain": "A table of lighthouse construction dates referenced in the text."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A table of lighthouse construction dates referenced in the text.",
-          "startsNewBlock": true
+          "ssml": "A table of lighthouse construction dates referenced in the text."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the appendix.",
-          "startsNewBlock": true
+          "ssml": "Start of the appendix."
         },
         {
           "ssml": "A table of lighthouse construction dates referenced in the text."

--- a/fixtures/article-html-native/utterances.json
+++ b/fixtures/article-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A self-contained article about lighthouse keeping.",
-          "startsNewBlock": true
+          "plain": "A self-contained article about lighthouse keeping."
         }
       ]
     },
@@ -21,8 +20,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A self-contained article about lighthouse keeping.",
-          "startsNewBlock": true
+          "ssml": "A self-contained article about lighthouse keeping."
         }
       ]
     }

--- a/fixtures/aside-html-native/utterances.json
+++ b/fixtures/aside-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "By the way, lighthouses were once staffed around the clock.",
-          "startsNewBlock": true
+          "plain": "By the way, lighthouses were once staffed around the clock."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the aside.",
-          "startsNewBlock": true
+          "plain": "Start of the aside."
         },
         {
           "plain": "By the way, lighthouses were once staffed around the clock."
@@ -240,8 +238,7 @@
       ],
       "utterances": [
         {
-          "ssml": "By the way, lighthouses were once staffed around the clock.",
-          "startsNewBlock": true
+          "ssml": "By the way, lighthouses were once staffed around the clock."
         }
       ]
     },
@@ -308,8 +305,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the aside.",
-          "startsNewBlock": true
+          "ssml": "Start of the aside."
         },
         {
           "ssml": "By the way, lighthouses were once staffed around the clock."

--- a/fixtures/audio-html-native/utterances.json
+++ b/fixtures/audio-html-native/utterances.json
@@ -75,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Audio.",
-          "startsNewBlock": true
+          "plain": "Audio."
         },
         {
           "plain": "Foghorn recording from the 1962 restoration"
@@ -303,8 +302,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Audio.",
-          "startsNewBlock": true
+          "ssml": "Audio."
         },
         {
           "ssml": "Foghorn recording from the 1962 restoration"

--- a/fixtures/bibliography-epub-type/utterances.json
+++ b/fixtures/bibliography-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Smith, J. Lighthouses of the Atlantic. 1988.",
-          "startsNewBlock": true
+          "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         }
       ]
     },
@@ -80,15 +78,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "plain": "End of the bibliography."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "plain": "End of the list."
@@ -244,8 +238,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "Start of the list."
@@ -254,8 +247,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -414,8 +404,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "List item."
@@ -424,8 +413,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -506,8 +494,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -516,8 +503,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -606,8 +592,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "Start of the list."
@@ -619,8 +604,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -1318,12 +1302,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Smith, J. Lighthouses of the Atlantic. 1988.",
-          "startsNewBlock": true
+          "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         }
       ]
     },
@@ -1390,15 +1372,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "ssml": "End of the bibliography."
@@ -1468,15 +1448,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "ssml": "End of the list."
@@ -1554,8 +1532,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "Start of the list."
@@ -1564,8 +1541,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "ssml": "End of the list."
@@ -1638,15 +1614,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."
@@ -1724,8 +1698,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "List item."
@@ -1734,8 +1707,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."
@@ -1816,8 +1788,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1826,8 +1797,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."
@@ -1916,8 +1886,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "Start of the list."
@@ -1929,8 +1898,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."

--- a/fixtures/bibliography-role-aria/utterances.json
+++ b/fixtures/bibliography-role-aria/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Smith, J. Lighthouses of the Atlantic. 1988.",
-          "startsNewBlock": true
+          "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         }
       ]
     },
@@ -80,15 +78,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "plain": "End of the bibliography."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "plain": "End of the list."
@@ -244,8 +238,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "Start of the list."
@@ -254,8 +247,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "plain": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -414,8 +404,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "List item."
@@ -424,8 +413,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -506,8 +494,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -516,8 +503,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -606,8 +592,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the bibliography.",
-          "startsNewBlock": true
+          "plain": "Start of the bibliography."
         },
         {
           "plain": "Start of the list."
@@ -619,8 +604,7 @@
           "plain": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Doe, A. Coastal Illumination. 1975."
@@ -1318,12 +1302,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Smith, J. Lighthouses of the Atlantic. 1988.",
-          "startsNewBlock": true
+          "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         }
       ]
     },
@@ -1390,15 +1372,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "ssml": "End of the bibliography."
@@ -1468,15 +1448,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "ssml": "End of the list."
@@ -1554,8 +1532,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "Start of the list."
@@ -1564,8 +1541,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "Doe, A. Coastal Illumination. 1975.",
-          "startsNewBlock": true
+          "ssml": "Doe, A. Coastal Illumination. 1975."
         },
         {
           "ssml": "End of the list."
@@ -1638,15 +1614,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."
@@ -1724,8 +1698,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "List item."
@@ -1734,8 +1707,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."
@@ -1816,8 +1788,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1826,8 +1797,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."
@@ -1916,8 +1886,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the bibliography.",
-          "startsNewBlock": true
+          "ssml": "Start of the bibliography."
         },
         {
           "ssml": "Start of the list."
@@ -1929,8 +1898,7 @@
           "ssml": "Smith, J. Lighthouses of the Atlantic. 1988."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Doe, A. Coastal Illumination. 1975."

--- a/fixtures/blockquote-html-native/utterances.json
+++ b/fixtures/blockquote-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "To be, or not to be, that is the question.",
-          "startsNewBlock": true
+          "plain": "To be, or not to be, that is the question."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the quote.",
-          "startsNewBlock": true
+          "plain": "Start of the quote."
         },
         {
           "plain": "To be, or not to be, that is the question."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "To be, or not to be, that is the question.",
-          "startsNewBlock": true
+          "ssml": "To be, or not to be, that is the question."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the quote.",
-          "startsNewBlock": true
+          "ssml": "Start of the quote."
         },
         {
           "ssml": "To be, or not to be, that is the question."

--- a/fixtures/chapter-epub-type/utterances.json
+++ b/fixtures/chapter-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Title of the chapter",
-          "startsNewBlock": true
+          "plain": "Title of the chapter"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the chapter.",
-          "startsNewBlock": true
+          "plain": "Start of the chapter."
         },
         {
           "plain": "Title of the chapter"
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Title of the chapter"
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the chapter.",
-          "startsNewBlock": true
+          "plain": "Start of the chapter."
         },
         {
           "plain": "Heading level 1."
@@ -251,8 +247,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Title of the chapter",
-          "startsNewBlock": true
+          "ssml": "Title of the chapter"
         }
       ]
     },
@@ -319,8 +314,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the chapter.",
-          "startsNewBlock": true
+          "ssml": "Start of the chapter."
         },
         {
           "ssml": "Title of the chapter"
@@ -393,8 +387,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Title of the chapter"
@@ -472,8 +465,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the chapter.",
-          "startsNewBlock": true
+          "ssml": "Start of the chapter."
         },
         {
           "ssml": "Heading level 1."

--- a/fixtures/chapter-role-aria/utterances.json
+++ b/fixtures/chapter-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Title of the chapter",
-          "startsNewBlock": true
+          "plain": "Title of the chapter"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the chapter.",
-          "startsNewBlock": true
+          "plain": "Start of the chapter."
         },
         {
           "plain": "Title of the chapter"
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Title of the chapter"
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the chapter.",
-          "startsNewBlock": true
+          "plain": "Start of the chapter."
         },
         {
           "plain": "Heading level 1."
@@ -251,8 +247,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Title of the chapter",
-          "startsNewBlock": true
+          "ssml": "Title of the chapter"
         }
       ]
     },
@@ -319,8 +314,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the chapter.",
-          "startsNewBlock": true
+          "ssml": "Start of the chapter."
         },
         {
           "ssml": "Title of the chapter"
@@ -393,8 +387,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Title of the chapter"
@@ -472,8 +465,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the chapter.",
-          "startsNewBlock": true
+          "ssml": "Start of the chapter."
         },
         {
           "ssml": "Heading level 1."

--- a/fixtures/colophon-epub-type/utterances.json
+++ b/fixtures/colophon-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Set in Georgia, 11pt, on recycled paper.",
-          "startsNewBlock": true
+          "plain": "Set in Georgia, 11pt, on recycled paper."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Colophon.",
-          "startsNewBlock": true
+          "plain": "Colophon."
         },
         {
           "plain": "Set in Georgia, 11pt, on recycled paper."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Set in Georgia, 11pt, on recycled paper.",
-          "startsNewBlock": true
+          "ssml": "Set in Georgia, 11pt, on recycled paper."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Colophon.",
-          "startsNewBlock": true
+          "ssml": "Colophon."
         },
         {
           "ssml": "Set in Georgia, 11pt, on recycled paper."

--- a/fixtures/colophon-role-aria/utterances.json
+++ b/fixtures/colophon-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Set in Georgia, 11pt, on recycled paper.",
-          "startsNewBlock": true
+          "plain": "Set in Georgia, 11pt, on recycled paper."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Colophon.",
-          "startsNewBlock": true
+          "plain": "Colophon."
         },
         {
           "plain": "Set in Georgia, 11pt, on recycled paper."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Set in Georgia, 11pt, on recycled paper.",
-          "startsNewBlock": true
+          "ssml": "Set in Georgia, 11pt, on recycled paper."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Colophon.",
-          "startsNewBlock": true
+          "ssml": "Colophon."
         },
         {
           "ssml": "Set in Georgia, 11pt, on recycled paper."

--- a/fixtures/conclusion-epub-type/utterances.json
+++ b/fixtures/conclusion-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Lighthouses remain a symbol of safe passage.",
-          "startsNewBlock": true
+          "plain": "Lighthouses remain a symbol of safe passage."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the conclusion.",
-          "startsNewBlock": true
+          "plain": "Start of the conclusion."
         },
         {
           "plain": "Lighthouses remain a symbol of safe passage."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Lighthouses remain a symbol of safe passage.",
-          "startsNewBlock": true
+          "ssml": "Lighthouses remain a symbol of safe passage."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the conclusion.",
-          "startsNewBlock": true
+          "ssml": "Start of the conclusion."
         },
         {
           "ssml": "Lighthouses remain a symbol of safe passage."

--- a/fixtures/conclusion-role-aria/utterances.json
+++ b/fixtures/conclusion-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Lighthouses remain a symbol of safe passage.",
-          "startsNewBlock": true
+          "plain": "Lighthouses remain a symbol of safe passage."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the conclusion.",
-          "startsNewBlock": true
+          "plain": "Start of the conclusion."
         },
         {
           "plain": "Lighthouses remain a symbol of safe passage."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Lighthouses remain a symbol of safe passage.",
-          "startsNewBlock": true
+          "ssml": "Lighthouses remain a symbol of safe passage."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the conclusion.",
-          "startsNewBlock": true
+          "ssml": "Start of the conclusion."
         },
         {
           "ssml": "Lighthouses remain a symbol of safe passage."

--- a/fixtures/cover-epub-type/utterances.json
+++ b/fixtures/cover-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Lighthouses of the Atlantic, by J. Smith",
-          "startsNewBlock": true
+          "plain": "Lighthouses of the Atlantic, by J. Smith"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Cover.",
-          "startsNewBlock": true
+          "plain": "Cover."
         },
         {
           "plain": "Lighthouses of the Atlantic, by J. Smith"
@@ -147,8 +145,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "Lighthouses of the Atlantic, by J. Smith"
@@ -226,8 +223,7 @@
       ],
       "utterances": [
         {
-          "plain": "Cover.",
-          "startsNewBlock": true
+          "plain": "Cover."
         },
         {
           "plain": "Image."
@@ -559,8 +555,7 @@
       ],
       "utterances": [
         {
-          "plain": "Cover.",
-          "startsNewBlock": true
+          "plain": "Cover."
         }
       ]
     },
@@ -572,8 +567,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Lighthouses of the Atlantic, by J. Smith",
-          "startsNewBlock": true
+          "ssml": "Lighthouses of the Atlantic, by J. Smith"
         }
       ]
     },
@@ -640,8 +634,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover.",
-          "startsNewBlock": true
+          "ssml": "Cover."
         },
         {
           "ssml": "Lighthouses of the Atlantic, by J. Smith"
@@ -711,8 +704,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "Lighthouses of the Atlantic, by J. Smith"
@@ -790,8 +782,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover.",
-          "startsNewBlock": true
+          "ssml": "Cover."
         },
         {
           "ssml": "Image."
@@ -1123,8 +1114,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover.",
-          "startsNewBlock": true
+          "ssml": "Cover."
         }
       ]
     }

--- a/fixtures/cover-role-aria/utterances.json
+++ b/fixtures/cover-role-aria/utterances.json
@@ -75,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "Lighthouses of the Atlantic, by J. Smith"
@@ -146,8 +145,7 @@
       ],
       "utterances": [
         {
-          "plain": "Cover.",
-          "startsNewBlock": true
+          "plain": "Cover."
         },
         {
           "plain": "Lighthouses of the Atlantic, by J. Smith"
@@ -225,8 +223,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "Cover."
@@ -628,8 +625,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "Lighthouses of the Atlantic, by J. Smith"
@@ -699,8 +695,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover.",
-          "startsNewBlock": true
+          "ssml": "Cover."
         },
         {
           "ssml": "Lighthouses of the Atlantic, by J. Smith"
@@ -778,8 +773,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "Cover."

--- a/fixtures/credit-epub-type/utterances.json
+++ b/fixtures/credit-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "plain": "Cover photograph by A. Keeper."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Cover photograph by A. Keeper."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "ssml": "Cover photograph by A. Keeper."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Cover photograph by A. Keeper."

--- a/fixtures/credits-epub-type/utterances.json
+++ b/fixtures/credits-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         }
       ]
     },
@@ -83,12 +81,10 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         },
         {
           "plain": "End of the credits."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         },
         {
           "plain": "End of the list."
@@ -247,15 +241,13 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -415,99 +405,6 @@
       "utterances": [
         {
           "plain": "Start of the credits."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Cover photograph by A. Keeper."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Maps by B. Cartographer."
-        },
-        {
-          "plain": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -516,14 +413,13 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Maps by B. Cartographer."
         },
         {
-          "plain": "End of the list."
+          "plain": "End of the credits."
         }
       ]
     },
@@ -532,7 +428,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ]
@@ -540,7 +435,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -549,7 +443,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -558,7 +451,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -568,7 +460,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -577,7 +468,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -587,7 +477,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -596,7 +485,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -606,11 +494,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the credits."
-        },
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -619,8 +503,108 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Maps by B. Cartographer."
+        },
+        {
+          "plain": "End of the list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the credits."
+        },
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Cover photograph by A. Keeper."
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -696,15 +680,13 @@
       ],
       "utterances": [
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -785,15 +767,13 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -874,8 +854,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Credit."
@@ -884,8 +863,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -977,8 +955,7 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Credit."
@@ -987,8 +964,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -1072,8 +1048,7 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1082,8 +1057,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1173,113 +1147,6 @@
       "utterances": [
         {
           "plain": "Start of the credits."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Credit."
-        },
-        {
-          "plain": "Cover photograph by A. Keeper."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Credit."
-        },
-        {
-          "plain": "Maps by B. Cartographer."
-        },
-        {
-          "plain": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -1291,8 +1158,111 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Credit."
+        },
+        {
+          "plain": "Maps by B. Cartographer."
+        },
+        {
+          "plain": "End of the credits."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Credit."
+        },
+        {
+          "plain": "Cover photograph by A. Keeper."
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1395,8 +1365,7 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -1408,8 +1377,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1433,12 +1401,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         }
       ]
     },
@@ -1508,12 +1474,10 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         },
         {
           "ssml": "End of the credits."
@@ -1583,15 +1547,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         },
         {
           "ssml": "End of the list."
@@ -1672,15 +1634,13 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         },
         {
           "ssml": "End of the list."
@@ -1753,15 +1713,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -1840,99 +1798,6 @@
       "utterances": [
         {
           "ssml": "Start of the credits."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Cover photograph by A. Keeper."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Maps by B. Cartographer."
-        },
-        {
-          "ssml": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1941,14 +1806,13 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Maps by B. Cartographer."
         },
         {
-          "ssml": "End of the list."
+          "ssml": "End of the credits."
         }
       ]
     },
@@ -1957,7 +1821,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ]
@@ -1965,7 +1828,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -1974,7 +1836,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -1983,7 +1844,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -1993,7 +1853,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2002,7 +1861,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2012,7 +1870,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2021,7 +1878,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2031,11 +1887,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the credits."
-        },
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -2044,8 +1896,108 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Maps by B. Cartographer."
+        },
+        {
+          "ssml": "End of the list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the credits."
+        },
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Cover photograph by A. Keeper."
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2121,15 +2073,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2210,15 +2160,13 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2299,8 +2247,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Credit."
@@ -2309,8 +2256,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2402,8 +2348,7 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Credit."
@@ -2412,8 +2357,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2497,8 +2441,7 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."
@@ -2507,8 +2450,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."
@@ -2598,113 +2540,6 @@
       "utterances": [
         {
           "ssml": "Start of the credits."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Credit."
-        },
-        {
-          "ssml": "Cover photograph by A. Keeper."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Credit."
-        },
-        {
-          "ssml": "Maps by B. Cartographer."
-        },
-        {
-          "ssml": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -2716,8 +2551,111 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Credit."
+        },
+        {
+          "ssml": "Maps by B. Cartographer."
+        },
+        {
+          "ssml": "End of the credits."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Credit."
+        },
+        {
+          "ssml": "Cover photograph by A. Keeper."
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."
@@ -2820,8 +2758,7 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -2833,8 +2770,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."

--- a/fixtures/credits-role-aria/utterances.json
+++ b/fixtures/credits-role-aria/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         }
       ]
     },
@@ -83,12 +81,10 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         },
         {
           "plain": "End of the credits."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         },
         {
           "plain": "End of the list."
@@ -247,15 +241,13 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "plain": "Maps by B. Cartographer."
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -415,99 +405,6 @@
       "utterances": [
         {
           "plain": "Start of the credits."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Cover photograph by A. Keeper."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Maps by B. Cartographer."
-        },
-        {
-          "plain": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -516,14 +413,13 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Maps by B. Cartographer."
         },
         {
-          "plain": "End of the list."
+          "plain": "End of the credits."
         }
       ]
     },
@@ -532,7 +428,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ]
@@ -540,7 +435,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -549,7 +443,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -558,7 +451,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -568,7 +460,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -577,7 +468,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -587,7 +477,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -596,7 +485,6 @@
         {
           "format": "plain",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -606,11 +494,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the credits."
-        },
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -619,8 +503,108 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Maps by B. Cartographer."
+        },
+        {
+          "plain": "End of the list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the credits."
+        },
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Cover photograph by A. Keeper."
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -696,15 +680,13 @@
       ],
       "utterances": [
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -785,15 +767,13 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -874,8 +854,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Credit."
@@ -884,8 +863,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -977,8 +955,7 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Credit."
@@ -987,8 +964,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "Credit.",
-          "startsNewBlock": true
+          "plain": "Credit."
         },
         {
           "plain": "Maps by B. Cartographer."
@@ -1072,8 +1048,7 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1082,8 +1057,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1173,113 +1147,6 @@
       "utterances": [
         {
           "plain": "Start of the credits."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Credit."
-        },
-        {
-          "plain": "Cover photograph by A. Keeper."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Credit."
-        },
-        {
-          "plain": "Maps by B. Cartographer."
-        },
-        {
-          "plain": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -1291,8 +1158,111 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Credit."
+        },
+        {
+          "plain": "Maps by B. Cartographer."
+        },
+        {
+          "plain": "End of the credits."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Credit."
+        },
+        {
+          "plain": "Cover photograph by A. Keeper."
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1395,8 +1365,7 @@
           "plain": "Start of the credits."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -1408,8 +1377,7 @@
           "plain": "Cover photograph by A. Keeper."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Credit."
@@ -1433,12 +1401,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         }
       ]
     },
@@ -1508,12 +1474,10 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Cover photograph by A. Keeper.",
-          "startsNewBlock": true
+          "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         },
         {
           "ssml": "End of the credits."
@@ -1583,15 +1547,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         },
         {
           "ssml": "End of the list."
@@ -1672,15 +1634,13 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Maps by B. Cartographer.",
-          "startsNewBlock": true
+          "ssml": "Maps by B. Cartographer."
         },
         {
           "ssml": "End of the list."
@@ -1753,15 +1713,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -1840,99 +1798,6 @@
       "utterances": [
         {
           "ssml": "Start of the credits."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Cover photograph by A. Keeper."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Maps by B. Cartographer."
-        },
-        {
-          "ssml": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1941,14 +1806,13 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Maps by B. Cartographer."
         },
         {
-          "ssml": "End of the list."
+          "ssml": "End of the credits."
         }
       ]
     },
@@ -1957,7 +1821,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ]
@@ -1965,7 +1828,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -1974,7 +1836,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -1983,7 +1844,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -1993,7 +1853,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2002,7 +1861,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2012,7 +1870,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2021,7 +1878,6 @@
         {
           "format": "ssml",
           "contextualize": [
-            "credits",
             "list",
             "listItem"
           ],
@@ -2031,11 +1887,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the credits."
-        },
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -2044,8 +1896,108 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Maps by B. Cartographer."
+        },
+        {
+          "ssml": "End of the list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "credits",
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the credits."
+        },
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Cover photograph by A. Keeper."
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2121,15 +2073,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2210,15 +2160,13 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2299,8 +2247,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Credit."
@@ -2309,8 +2256,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2402,8 +2348,7 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Credit."
@@ -2412,8 +2357,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "Credit.",
-          "startsNewBlock": true
+          "ssml": "Credit."
         },
         {
           "ssml": "Maps by B. Cartographer."
@@ -2497,8 +2441,7 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."
@@ -2507,8 +2450,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."
@@ -2598,113 +2540,6 @@
       "utterances": [
         {
           "ssml": "Start of the credits."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Credit."
-        },
-        {
-          "ssml": "Cover photograph by A. Keeper."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Credit."
-        },
-        {
-          "ssml": "Maps by B. Cartographer."
-        },
-        {
-          "ssml": "End of the credits."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem",
-            "credit"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -2716,8 +2551,111 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Credit."
+        },
+        {
+          "ssml": "Maps by B. Cartographer."
+        },
+        {
+          "ssml": "End of the credits."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem",
+            "credit"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Credit."
+        },
+        {
+          "ssml": "Cover photograph by A. Keeper."
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."
@@ -2820,8 +2758,7 @@
           "ssml": "Start of the credits."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -2833,8 +2770,7 @@
           "ssml": "Cover photograph by A. Keeper."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Credit."

--- a/fixtures/dedication-epub-type/utterances.json
+++ b/fixtures/dedication-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "For every keeper who lit the lamp at dusk.",
-          "startsNewBlock": true
+          "plain": "For every keeper who lit the lamp at dusk."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Dedication.",
-          "startsNewBlock": true
+          "plain": "Dedication."
         },
         {
           "plain": "For every keeper who lit the lamp at dusk."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "For every keeper who lit the lamp at dusk.",
-          "startsNewBlock": true
+          "ssml": "For every keeper who lit the lamp at dusk."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Dedication.",
-          "startsNewBlock": true
+          "ssml": "Dedication."
         },
         {
           "ssml": "For every keeper who lit the lamp at dusk."

--- a/fixtures/dedication-role-aria/utterances.json
+++ b/fixtures/dedication-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "For every keeper who lit the lamp at dusk.",
-          "startsNewBlock": true
+          "plain": "For every keeper who lit the lamp at dusk."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Dedication.",
-          "startsNewBlock": true
+          "plain": "Dedication."
         },
         {
           "plain": "For every keeper who lit the lamp at dusk."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "For every keeper who lit the lamp at dusk.",
-          "startsNewBlock": true
+          "ssml": "For every keeper who lit the lamp at dusk."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Dedication.",
-          "startsNewBlock": true
+          "ssml": "Dedication."
         },
         {
           "ssml": "For every keeper who lit the lamp at dusk."

--- a/fixtures/definition-epub-type/utterances.json
+++ b/fixtures/definition-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A structure that contains an enumeration of related content items.",
-          "startsNewBlock": true
+          "plain": "A structure that contains an enumeration of related content items."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the glossary.",
-          "startsNewBlock": true
+          "plain": "Start of the glossary."
         },
         {
           "plain": "A structure that contains an enumeration of related content items."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A structure that contains an enumeration of related content items.",
-          "startsNewBlock": true
+          "ssml": "A structure that contains an enumeration of related content items."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the glossary.",
-          "startsNewBlock": true
+          "ssml": "Start of the glossary."
         },
         {
           "ssml": "A structure that contains an enumeration of related content items."

--- a/fixtures/details-summary-html-native/utterances.json
+++ b/fixtures/details-summary-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Click to expand",
-          "startsNewBlock": true
+          "plain": "Click to expand"
         },
         {
           "plain": "Additional details the reader can expand."
@@ -82,8 +81,7 @@
           "plain": "Start of the details."
         },
         {
-          "plain": "Click to expand",
-          "startsNewBlock": true
+          "plain": "Click to expand"
         },
         {
           "plain": "Additional details the reader can expand."
@@ -156,8 +154,7 @@
       ],
       "utterances": [
         {
-          "plain": "Summary.",
-          "startsNewBlock": true
+          "plain": "Summary."
         },
         {
           "plain": "Click to expand"
@@ -241,8 +238,7 @@
           "plain": "Start of the details."
         },
         {
-          "plain": "Summary.",
-          "startsNewBlock": true
+          "plain": "Summary."
         },
         {
           "plain": "Click to expand"
@@ -580,8 +576,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Click to expand",
-          "startsNewBlock": true
+          "ssml": "Click to expand"
         },
         {
           "ssml": "Additional details the reader can expand."
@@ -654,8 +649,7 @@
           "ssml": "Start of the details."
         },
         {
-          "ssml": "Click to expand",
-          "startsNewBlock": true
+          "ssml": "Click to expand"
         },
         {
           "ssml": "Additional details the reader can expand."
@@ -728,8 +722,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Summary.",
-          "startsNewBlock": true
+          "ssml": "Summary."
         },
         {
           "ssml": "Click to expand"
@@ -813,8 +806,7 @@
           "ssml": "Start of the details."
         },
         {
-          "ssml": "Summary.",
-          "startsNewBlock": true
+          "ssml": "Summary."
         },
         {
           "ssml": "Click to expand"

--- a/fixtures/endnotes-epub-type/utterances.json
+++ b/fixtures/endnotes-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "See introduction for background.",
-          "startsNewBlock": true
+          "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         }
       ]
     },
@@ -286,15 +284,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         },
         {
           "plain": "End of the endnotes."
@@ -570,15 +566,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         },
         {
           "plain": "End of the list."
@@ -886,8 +880,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "Start of the list."
@@ -896,8 +889,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         },
         {
           "plain": "End of the list."
@@ -1176,15 +1168,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -1492,8 +1482,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "List item."
@@ -1502,8 +1491,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -1814,8 +1802,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -1824,8 +1811,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -2168,8 +2154,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "Start of the list."
@@ -2181,8 +2166,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -17277,8 +17261,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "End of the endnotes."
@@ -18402,8 +18385,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "End of the list."
@@ -19623,8 +19605,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "Start of the list."
@@ -20754,12 +20735,10 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         }
       ]
     },
@@ -21976,15 +21955,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "List item."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "End of the endnotes."
@@ -23204,15 +23181,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "End of the list."
@@ -24528,8 +24503,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "Start of the list."
@@ -24538,8 +24512,7 @@
           "plain": "List item."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "End of the list."
@@ -24557,12 +24530,10 @@
       ],
       "utterances": [
         {
-          "ssml": "See introduction for background.",
-          "startsNewBlock": true
+          "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         }
       ]
     },
@@ -24835,15 +24806,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         },
         {
           "ssml": "End of the endnotes."
@@ -25119,15 +25088,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         },
         {
           "ssml": "End of the list."
@@ -25435,8 +25402,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "Start of the list."
@@ -25445,8 +25411,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         },
         {
           "ssml": "End of the list."
@@ -25725,15 +25690,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -26041,8 +26004,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "List item."
@@ -26051,8 +26013,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -26363,8 +26324,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -26373,8 +26333,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -26717,8 +26676,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "Start of the list."
@@ -26730,8 +26688,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -41826,8 +41783,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "End of the endnotes."
@@ -42951,8 +42907,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "End of the list."
@@ -44172,8 +44127,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "Start of the list."
@@ -45303,12 +45257,10 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         }
       ]
     },
@@ -46525,15 +46477,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "List item."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "End of the endnotes."
@@ -47753,15 +47703,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "End of the list."
@@ -49077,8 +49025,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "Start of the list."
@@ -49087,8 +49034,7 @@
           "ssml": "List item."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "End of the list."

--- a/fixtures/endnotes-role-aria/utterances.json
+++ b/fixtures/endnotes-role-aria/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "See introduction for background.",
-          "startsNewBlock": true
+          "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         }
       ]
     },
@@ -146,15 +144,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         },
         {
           "plain": "End of the endnotes."
@@ -290,15 +286,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         },
         {
           "plain": "End of the list."
@@ -450,8 +444,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "Start of the list."
@@ -460,8 +453,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "See chapter three for details.",
-          "startsNewBlock": true
+          "plain": "See chapter three for details."
         },
         {
           "plain": "End of the list."
@@ -600,15 +592,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -760,8 +750,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "List item."
@@ -770,8 +759,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -926,8 +914,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -936,8 +923,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -1108,8 +1094,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "Start of the list."
@@ -1121,8 +1106,7 @@
           "plain": "See introduction for background."
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "See chapter three for details."
@@ -4793,8 +4777,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "End of the endnotes."
@@ -5166,8 +5149,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "End of the list."
@@ -5571,8 +5553,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the endnotes.",
-          "startsNewBlock": true
+          "plain": "Start of the endnotes."
         },
         {
           "plain": "Start of the list."
@@ -5593,12 +5574,10 @@
       ],
       "utterances": [
         {
-          "ssml": "See introduction for background.",
-          "startsNewBlock": true
+          "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         }
       ]
     },
@@ -5731,15 +5710,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         },
         {
           "ssml": "End of the endnotes."
@@ -5875,15 +5852,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         },
         {
           "ssml": "End of the list."
@@ -6035,8 +6010,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "Start of the list."
@@ -6045,8 +6019,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "See chapter three for details.",
-          "startsNewBlock": true
+          "ssml": "See chapter three for details."
         },
         {
           "ssml": "End of the list."
@@ -6185,15 +6158,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -6345,8 +6316,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "List item."
@@ -6355,8 +6325,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -6511,8 +6480,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -6521,8 +6489,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -6693,8 +6660,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "Start of the list."
@@ -6706,8 +6672,7 @@
           "ssml": "See introduction for background."
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "See chapter three for details."
@@ -10378,8 +10343,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "End of the endnotes."
@@ -10751,8 +10715,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "End of the list."
@@ -11156,8 +11119,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the endnotes.",
-          "startsNewBlock": true
+          "ssml": "Start of the endnotes."
         },
         {
           "ssml": "Start of the list."

--- a/fixtures/epigraph-epub-type/utterances.json
+++ b/fixtures/epigraph-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A lighthouse is a compromise with the sea. — Anonymous",
-          "startsNewBlock": true
+          "plain": "A lighthouse is a compromise with the sea. — Anonymous"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Epigraph.",
-          "startsNewBlock": true
+          "plain": "Epigraph."
         },
         {
           "plain": "A lighthouse is a compromise with the sea. — Anonymous"
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A lighthouse is a compromise with the sea. — Anonymous",
-          "startsNewBlock": true
+          "ssml": "A lighthouse is a compromise with the sea. — Anonymous"
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Epigraph.",
-          "startsNewBlock": true
+          "ssml": "Epigraph."
         },
         {
           "ssml": "A lighthouse is a compromise with the sea. — Anonymous"

--- a/fixtures/epigraph-role-aria/utterances.json
+++ b/fixtures/epigraph-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A lighthouse is a compromise with the sea. — Anonymous",
-          "startsNewBlock": true
+          "plain": "A lighthouse is a compromise with the sea. — Anonymous"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Epigraph.",
-          "startsNewBlock": true
+          "plain": "Epigraph."
         },
         {
           "plain": "A lighthouse is a compromise with the sea. — Anonymous"
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A lighthouse is a compromise with the sea. — Anonymous",
-          "startsNewBlock": true
+          "ssml": "A lighthouse is a compromise with the sea. — Anonymous"
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Epigraph.",
-          "startsNewBlock": true
+          "ssml": "Epigraph."
         },
         {
           "ssml": "A lighthouse is a compromise with the sea. — Anonymous"

--- a/fixtures/epilogue-epub-type/utterances.json
+++ b/fixtures/epilogue-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "plain": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the epilogue.",
-          "startsNewBlock": true
+          "plain": "Start of the epilogue."
         },
         {
           "plain": "The lamp still turns, though no one climbs the stairs anymore."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "ssml": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the epilogue.",
-          "startsNewBlock": true
+          "ssml": "Start of the epilogue."
         },
         {
           "ssml": "The lamp still turns, though no one climbs the stairs anymore."

--- a/fixtures/epilogue-role-aria/utterances.json
+++ b/fixtures/epilogue-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "plain": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the epilogue.",
-          "startsNewBlock": true
+          "plain": "Start of the epilogue."
         },
         {
           "plain": "The lamp still turns, though no one climbs the stairs anymore."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "ssml": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the epilogue.",
-          "startsNewBlock": true
+          "ssml": "Start of the epilogue."
         },
         {
           "ssml": "The lamp still turns, though no one climbs the stairs anymore."

--- a/fixtures/errata-epub-type/utterances.json
+++ b/fixtures/errata-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Page 42: 'lightouse' should read 'lighthouse'.",
-          "startsNewBlock": true
+          "plain": "Page 42: 'lightouse' should read 'lighthouse'."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Errata.",
-          "startsNewBlock": true
+          "plain": "Errata."
         },
         {
           "plain": "Page 42: 'lightouse' should read 'lighthouse'."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Page 42: 'lightouse' should read 'lighthouse'.",
-          "startsNewBlock": true
+          "ssml": "Page 42: 'lightouse' should read 'lighthouse'."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Errata.",
-          "startsNewBlock": true
+          "ssml": "Errata."
         },
         {
           "ssml": "Page 42: 'lightouse' should read 'lighthouse'."

--- a/fixtures/errata-role-aria/utterances.json
+++ b/fixtures/errata-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Page 42: 'lightouse' should read 'lighthouse'.",
-          "startsNewBlock": true
+          "plain": "Page 42: 'lightouse' should read 'lighthouse'."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Errata.",
-          "startsNewBlock": true
+          "plain": "Errata."
         },
         {
           "plain": "Page 42: 'lightouse' should read 'lighthouse'."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Page 42: 'lightouse' should read 'lighthouse'.",
-          "startsNewBlock": true
+          "ssml": "Page 42: 'lightouse' should read 'lighthouse'."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Errata.",
-          "startsNewBlock": true
+          "ssml": "Errata."
         },
         {
           "ssml": "Page 42: 'lightouse' should read 'lighthouse'."

--- a/fixtures/example-epub-type/utterances.json
+++ b/fixtures/example-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "For instance, a Fresnel lens focuses light into a narrow beam.",
-          "startsNewBlock": true
+          "plain": "For instance, a Fresnel lens focuses light into a narrow beam."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Example.",
-          "startsNewBlock": true
+          "plain": "Example."
         },
         {
           "plain": "For instance, a Fresnel lens focuses light into a narrow beam."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "For instance, a Fresnel lens focuses light into a narrow beam.",
-          "startsNewBlock": true
+          "ssml": "For instance, a Fresnel lens focuses light into a narrow beam."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Example.",
-          "startsNewBlock": true
+          "ssml": "Example."
         },
         {
           "ssml": "For instance, a Fresnel lens focuses light into a narrow beam."

--- a/fixtures/example-role-aria/utterances.json
+++ b/fixtures/example-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "For instance, a Fresnel lens focuses light into a narrow beam.",
-          "startsNewBlock": true
+          "plain": "For instance, a Fresnel lens focuses light into a narrow beam."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Example.",
-          "startsNewBlock": true
+          "plain": "Example."
         },
         {
           "plain": "For instance, a Fresnel lens focuses light into a narrow beam."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "For instance, a Fresnel lens focuses light into a narrow beam.",
-          "startsNewBlock": true
+          "ssml": "For instance, a Fresnel lens focuses light into a narrow beam."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Example.",
-          "startsNewBlock": true
+          "ssml": "Example."
         },
         {
           "ssml": "For instance, a Fresnel lens focuses light into a narrow beam."

--- a/fixtures/figure-basic-html-native/utterances.json
+++ b/fixtures/figure-basic-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A bar chart showing sales growth",
-          "startsNewBlock": true
+          "plain": "A bar chart showing sales growth"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "A bar chart showing sales growth"
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "A bar chart showing sales growth"
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "Image."
@@ -1221,8 +1217,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "End of the figure."
@@ -1237,8 +1232,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A bar chart showing sales growth",
-          "startsNewBlock": true
+          "ssml": "A bar chart showing sales growth"
         }
       ]
     },
@@ -1305,8 +1299,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "A bar chart showing sales growth"
@@ -1379,8 +1372,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "A bar chart showing sales growth"
@@ -1458,8 +1450,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "Image."
@@ -2450,8 +2441,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "End of the figure."

--- a/fixtures/figure-basic-role-aria/utterances.json
+++ b/fixtures/figure-basic-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A bar chart showing sales growth",
-          "startsNewBlock": true
+          "plain": "A bar chart showing sales growth"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "A bar chart showing sales growth"
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "A bar chart showing sales growth"
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "Image."
@@ -1221,8 +1217,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "End of the figure."
@@ -1237,8 +1232,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A bar chart showing sales growth",
-          "startsNewBlock": true
+          "ssml": "A bar chart showing sales growth"
         }
       ]
     },
@@ -1305,8 +1299,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "A bar chart showing sales growth"
@@ -1379,8 +1372,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "A bar chart showing sales growth"
@@ -1458,8 +1450,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "Image."
@@ -2450,8 +2441,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "End of the figure."

--- a/fixtures/figure-caption-html-native/utterances.json
+++ b/fixtures/figure-caption-html-native/utterances.json
@@ -75,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "ASCII Art of a cat face"
@@ -306,8 +305,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "ASCII Art of a cat face"

--- a/fixtures/figure-caption-role-aria/utterances.json
+++ b/fixtures/figure-caption-role-aria/utterances.json
@@ -75,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "ASCII Art of a cat face"
@@ -306,8 +305,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "ASCII Art of a cat face"

--- a/fixtures/figure-describedby/utterances.json
+++ b/fixtures/figure-describedby/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Sales chart",
-          "startsNewBlock": true
+          "plain": "Sales chart"
         },
         {
           "plain": "Full audio description: sales grew 12% year over year, driven primarily by the Q4 holiday season."
@@ -79,8 +78,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "Sales chart"
@@ -156,8 +154,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "Sales chart"
@@ -238,8 +235,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "Image."
@@ -581,8 +577,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the figure.",
-          "startsNewBlock": true
+          "plain": "Start of the figure."
         },
         {
           "plain": "Full audio description: sales grew 12% year over year, driven primarily by the Q4 holiday season."
@@ -1261,8 +1256,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Sales chart",
-          "startsNewBlock": true
+          "ssml": "Sales chart"
         },
         {
           "ssml": "Full audio description: sales grew 12% year over year, driven primarily by the Q4 holiday season."
@@ -1332,8 +1326,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "Sales chart"
@@ -1409,8 +1402,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "Sales chart"
@@ -1491,8 +1483,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "Image."
@@ -1834,8 +1825,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the figure.",
-          "startsNewBlock": true
+          "ssml": "Start of the figure."
         },
         {
           "ssml": "Full audio description: sales grew 12% year over year, driven primarily by the Q4 holiday season."

--- a/fixtures/footnote-epub-type/utterances.json
+++ b/fixtures/footnote-epub-type/utterances.json
@@ -9,8 +9,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "plain": "Text of the footnote."
@@ -60,8 +59,7 @@
       "utterances": [
         {
           "plain": "This text has a footnote Text of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -81,8 +79,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "plain": "Text of the footnote."
@@ -107,8 +104,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote Text of the footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote Text of the footnote."
         }
       ]
     },
@@ -161,8 +157,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "plain": "Start of the footnote. Text of the footnote. End of the footnote."
@@ -224,8 +219,7 @@
       "utterances": [
         {
           "plain": "This text has a footnote Start of the footnote. Text of the footnote. End of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -249,8 +243,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "plain": "Start of the footnote. Text of the footnote. End of the footnote."
@@ -279,8 +272,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote Start of the footnote. Text of the footnote. End of the footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote Start of the footnote. Text of the footnote. End of the footnote."
         }
       ]
     },
@@ -2034,8 +2026,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         }
       ]
     },
@@ -2644,8 +2635,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         }
       ]
     },
@@ -2658,8 +2648,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "ssml": "Text of the footnote."
@@ -2709,8 +2698,7 @@
       "utterances": [
         {
           "ssml": "This text has a footnote Text of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -2730,8 +2718,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "ssml": "Text of the footnote."
@@ -2756,8 +2743,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote Text of the footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote Text of the footnote."
         }
       ]
     },
@@ -2810,8 +2796,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "ssml": "Start of the footnote. Text of the footnote. End of the footnote."
@@ -2873,8 +2858,7 @@
       "utterances": [
         {
           "ssml": "This text has a footnote Start of the footnote. Text of the footnote. End of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -2898,8 +2882,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "ssml": "Start of the footnote. Text of the footnote. End of the footnote."
@@ -2928,8 +2911,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote Start of the footnote. Text of the footnote. End of the footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote Start of the footnote. Text of the footnote. End of the footnote."
         }
       ]
     },
@@ -4683,8 +4665,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         }
       ]
     },
@@ -5293,8 +5274,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         }
       ]
     }

--- a/fixtures/footnote-role-aria/utterances.json
+++ b/fixtures/footnote-role-aria/utterances.json
@@ -9,8 +9,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "language": "en",
@@ -64,8 +63,7 @@
       "utterances": [
         {
           "plain": "This text has a footnote 1. Text of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -85,8 +83,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "plain": "Text of the footnote."
@@ -114,8 +111,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote 1. Text of the footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote 1. Text of the footnote."
         }
       ]
     },
@@ -168,8 +164,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "plain": "Start of the footnote. Text of the footnote. 1. End of the footnote.",
@@ -232,8 +227,7 @@
       "utterances": [
         {
           "plain": "This text has a footnote Start of the footnote. 1. Text of the footnote. End of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -257,8 +251,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         },
         {
           "plain": "Start of the footnote. Text of the footnote. 1. End of the footnote."
@@ -287,8 +280,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote Start of the footnote. 1. Text of the footnote. End of the footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote Start of the footnote. 1. Text of the footnote. End of the footnote."
         }
       ]
     },
@@ -2042,8 +2034,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         }
       ]
     },
@@ -2652,8 +2643,7 @@
       ],
       "utterances": [
         {
-          "plain": "This text has a footnote.",
-          "startsNewBlock": true
+          "plain": "This text has a footnote."
         }
       ]
     },
@@ -2666,8 +2656,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "language": "en",
@@ -2721,8 +2710,7 @@
       "utterances": [
         {
           "ssml": "This text has a footnote 1. Text of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -2742,8 +2730,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "ssml": "Text of the footnote."
@@ -2771,8 +2758,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote 1. Text of the footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote 1. Text of the footnote."
         }
       ]
     },
@@ -2825,8 +2811,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "ssml": "Start of the footnote. Text of the footnote. 1. End of the footnote.",
@@ -2889,8 +2874,7 @@
       "utterances": [
         {
           "ssml": "This text has a footnote Start of the footnote. 1. Text of the footnote. End of the footnote.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -2914,8 +2898,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         },
         {
           "ssml": "Start of the footnote. Text of the footnote. 1. End of the footnote."
@@ -2944,8 +2927,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote Start of the footnote. 1. Text of the footnote. End of the footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote Start of the footnote. 1. Text of the footnote. End of the footnote."
         }
       ]
     },
@@ -4699,8 +4681,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         }
       ]
     },
@@ -5309,8 +5290,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This text has a footnote.",
-          "startsNewBlock": true
+          "ssml": "This text has a footnote."
         }
       ]
     }

--- a/fixtures/foreword-epub-type/utterances.json
+++ b/fixtures/foreword-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A respected maritime historian introduces this account of the coastline's lighthouses.",
-          "startsNewBlock": true
+          "plain": "A respected maritime historian introduces this account of the coastline's lighthouses."
         }
       ]
     },
@@ -21,8 +20,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A respected maritime historian introduces this account of the coastline's lighthouses.",
-          "startsNewBlock": true
+          "ssml": "A respected maritime historian introduces this account of the coastline's lighthouses."
         }
       ]
     }

--- a/fixtures/foreword-role-aria/utterances.json
+++ b/fixtures/foreword-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "A respected maritime historian introduces this account of the coastline's lighthouses.",
-          "startsNewBlock": true
+          "plain": "A respected maritime historian introduces this account of the coastline's lighthouses."
         }
       ]
     },
@@ -21,8 +20,7 @@
       ],
       "utterances": [
         {
-          "ssml": "A respected maritime historian introduces this account of the coastline's lighthouses.",
-          "startsNewBlock": true
+          "ssml": "A respected maritime historian introduces this account of the coastline's lighthouses."
         }
       ]
     }

--- a/fixtures/glossary-epub-type/utterances.json
+++ b/fixtures/glossary-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Fresnel lens",
-          "startsNewBlock": true
+          "plain": "Fresnel lens"
         },
         {
           "plain": "A compact lens for focusing light."
@@ -85,8 +84,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the glossary.",
-          "startsNewBlock": true
+          "plain": "Start of the glossary."
         },
         {
           "plain": "Fresnel lens"
@@ -168,8 +166,7 @@
       ],
       "utterances": [
         {
-          "plain": "Term.",
-          "startsNewBlock": true
+          "plain": "Term."
         },
         {
           "plain": "Fresnel lens"
@@ -259,8 +256,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the glossary.",
-          "startsNewBlock": true
+          "plain": "Start of the glossary."
         },
         {
           "plain": "Term."
@@ -293,8 +289,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Fresnel lens",
-          "startsNewBlock": true
+          "ssml": "Fresnel lens"
         },
         {
           "ssml": "A compact lens for focusing light."
@@ -370,8 +365,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the glossary.",
-          "startsNewBlock": true
+          "ssml": "Start of the glossary."
         },
         {
           "ssml": "Fresnel lens"
@@ -453,8 +447,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Term.",
-          "startsNewBlock": true
+          "ssml": "Term."
         },
         {
           "ssml": "Fresnel lens"
@@ -544,8 +537,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the glossary.",
-          "startsNewBlock": true
+          "ssml": "Start of the glossary."
         },
         {
           "ssml": "Term."

--- a/fixtures/glossary-role-aria/utterances.json
+++ b/fixtures/glossary-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Fresnel lens",
-          "startsNewBlock": true
+          "plain": "Fresnel lens"
         },
         {
           "plain": "A compact lens for focusing light."
@@ -85,8 +84,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the glossary.",
-          "startsNewBlock": true
+          "plain": "Start of the glossary."
         },
         {
           "plain": "Fresnel lens"
@@ -168,8 +166,7 @@
       ],
       "utterances": [
         {
-          "plain": "Term.",
-          "startsNewBlock": true
+          "plain": "Term."
         },
         {
           "plain": "Term."
@@ -265,8 +262,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the glossary.",
-          "startsNewBlock": true
+          "plain": "Start of the glossary."
         },
         {
           "plain": "Term."
@@ -305,8 +301,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Fresnel lens",
-          "startsNewBlock": true
+          "ssml": "Fresnel lens"
         },
         {
           "ssml": "A compact lens for focusing light."
@@ -382,8 +377,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the glossary.",
-          "startsNewBlock": true
+          "ssml": "Start of the glossary."
         },
         {
           "ssml": "Fresnel lens"
@@ -465,8 +459,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Term.",
-          "startsNewBlock": true
+          "ssml": "Term."
         },
         {
           "ssml": "Term."
@@ -562,8 +555,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the glossary.",
-          "startsNewBlock": true
+          "ssml": "Start of the glossary."
         },
         {
           "ssml": "Term."

--- a/fixtures/heading-html-native/utterances.json
+++ b/fixtures/heading-html-native/utterances.json
@@ -8,28 +8,22 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -96,31 +90,25 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -187,31 +175,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -286,34 +268,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -380,31 +356,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -479,34 +449,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -581,34 +545,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -691,37 +649,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -788,31 +740,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -887,34 +833,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -989,34 +929,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1099,37 +1033,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1204,34 +1132,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1314,37 +1236,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1427,37 +1343,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1548,40 +1458,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1648,31 +1552,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1747,34 +1645,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1849,34 +1741,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1959,37 +1845,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2064,34 +1944,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2174,37 +2048,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2287,37 +2155,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2408,40 +2270,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2516,34 +2372,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2626,37 +2476,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2739,37 +2583,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2860,40 +2698,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2976,37 +2808,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3097,40 +2923,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3221,40 +3041,34 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3353,43 +3167,37 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3456,28 +3264,22 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3555,31 +3357,25 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3657,31 +3453,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3767,34 +3557,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3872,31 +3656,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3982,34 +3760,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4095,34 +3867,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4216,37 +3982,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4324,31 +4084,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4434,34 +4188,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4547,34 +4295,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4668,37 +4410,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4784,34 +4520,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4905,37 +4635,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5029,37 +4753,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5161,40 +4879,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5272,31 +4984,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5382,34 +5088,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5495,34 +5195,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5616,37 +5310,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5732,34 +5420,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5853,37 +5535,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5977,37 +5653,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6109,40 +5779,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6228,34 +5892,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6349,37 +6007,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6473,37 +6125,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6605,40 +6251,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6732,37 +6372,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6864,40 +6498,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6999,40 +6627,34 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -7142,43 +6764,37 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -7193,28 +6809,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7281,31 +6891,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7372,31 +6976,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7471,34 +7069,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7565,31 +7157,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7664,34 +7250,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7766,34 +7346,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7876,37 +7450,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7973,31 +7541,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8072,34 +7634,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8174,34 +7730,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8284,37 +7834,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8389,34 +7933,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8499,37 +8037,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8612,37 +8144,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8733,40 +8259,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8833,31 +8353,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8932,34 +8446,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9034,34 +8542,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9144,37 +8646,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9249,34 +8745,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9359,37 +8849,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9472,37 +8956,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9593,40 +9071,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9701,34 +9173,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9811,37 +9277,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9924,37 +9384,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10045,40 +9499,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10161,37 +9609,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10282,40 +9724,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10406,40 +9842,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10538,43 +9968,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10641,28 +10065,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -10740,31 +10158,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -10842,31 +10254,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -10952,34 +10358,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11057,31 +10457,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11167,34 +10561,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11280,34 +10668,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11401,37 +10783,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11509,31 +10885,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11619,34 +10989,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11732,34 +11096,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11853,37 +11211,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11969,34 +11321,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12090,37 +11436,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12214,37 +11554,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12346,40 +11680,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12457,31 +11785,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12567,34 +11889,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12680,34 +11996,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12801,37 +12111,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12917,34 +12221,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13038,37 +12336,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13162,37 +12454,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13294,40 +12580,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13413,34 +12693,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13534,37 +12808,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13658,37 +12926,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13790,40 +13052,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13917,37 +13173,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -14049,40 +13299,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -14184,40 +13428,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -14327,43 +13565,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"

--- a/fixtures/heading-role-aria/utterances.json
+++ b/fixtures/heading-role-aria/utterances.json
@@ -8,28 +8,22 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -96,31 +90,25 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -187,31 +175,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -286,34 +268,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -380,31 +356,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -479,34 +449,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -581,34 +545,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -691,37 +649,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -788,31 +740,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -887,34 +833,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -989,34 +929,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1099,37 +1033,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1204,34 +1132,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1314,37 +1236,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1427,37 +1343,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1548,40 +1458,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1648,31 +1552,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1747,34 +1645,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1849,34 +1741,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -1959,37 +1845,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2064,34 +1944,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2174,37 +2048,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2287,37 +2155,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2408,40 +2270,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2516,34 +2372,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2626,37 +2476,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2739,37 +2583,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2860,40 +2698,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -2976,37 +2808,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3097,40 +2923,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3221,40 +3041,34 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3353,43 +3167,37 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Aside heading",
-          "startsNewBlock": true
+          "plain": "Aside heading"
         }
       ]
     },
@@ -3456,28 +3264,22 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3555,31 +3357,25 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3657,31 +3453,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3767,34 +3557,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3872,31 +3656,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -3982,34 +3760,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4095,34 +3867,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4216,37 +3982,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4324,31 +4084,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4434,34 +4188,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4547,34 +4295,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4668,37 +4410,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4784,34 +4520,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -4905,37 +4635,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5029,37 +4753,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5161,40 +4879,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Note heading",
-          "startsNewBlock": true
+          "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5272,31 +4984,25 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5382,34 +5088,28 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5495,34 +5195,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5616,37 +5310,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5732,34 +5420,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5853,37 +5535,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -5977,37 +5653,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6109,40 +5779,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Detail heading",
-          "startsNewBlock": true
+          "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6228,34 +5892,28 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6349,37 +6007,31 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6473,37 +6125,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6605,40 +6251,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Subsection i",
-          "startsNewBlock": true
+          "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6732,37 +6372,31 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6864,40 +6498,34 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Section A",
-          "startsNewBlock": true
+          "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -6999,40 +6627,34 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -7142,43 +6764,37 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Heading level 2.",
-          "startsNewBlock": true
+          "plain": "Heading level 2."
         },
         {
           "plain": "Section A"
         },
         {
-          "plain": "Heading level 3.",
-          "startsNewBlock": true
+          "plain": "Heading level 3."
         },
         {
           "plain": "Subsection i"
         },
         {
-          "plain": "Heading level 4.",
-          "startsNewBlock": true
+          "plain": "Heading level 4."
         },
         {
           "plain": "Detail heading"
         },
         {
-          "plain": "Heading level 5.",
-          "startsNewBlock": true
+          "plain": "Heading level 5."
         },
         {
           "plain": "Note heading"
         },
         {
-          "plain": "Heading level 6.",
-          "startsNewBlock": true
+          "plain": "Heading level 6."
         },
         {
           "plain": "Aside heading"
@@ -7193,28 +6809,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7281,31 +6891,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7372,31 +6976,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7471,34 +7069,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7565,31 +7157,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7664,34 +7250,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7766,34 +7346,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7876,37 +7450,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -7973,31 +7541,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8072,34 +7634,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8174,34 +7730,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8284,37 +7834,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8389,34 +7933,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8499,37 +8037,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8612,37 +8144,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8733,40 +8259,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8833,31 +8353,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -8932,34 +8446,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9034,34 +8542,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9144,37 +8646,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9249,34 +8745,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9359,37 +8849,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9472,37 +8956,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9593,40 +9071,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9701,34 +9173,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9811,37 +9277,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -9924,37 +9384,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10045,40 +9499,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10161,37 +9609,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10282,40 +9724,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10406,40 +9842,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10538,43 +9968,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Aside heading",
-          "startsNewBlock": true
+          "ssml": "Aside heading"
         }
       ]
     },
@@ -10641,28 +10065,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -10740,31 +10158,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -10842,31 +10254,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -10952,34 +10358,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11057,31 +10457,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11167,34 +10561,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11280,34 +10668,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11401,37 +10783,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11509,31 +10885,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11619,34 +10989,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11732,34 +11096,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11853,37 +11211,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -11969,34 +11321,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12090,37 +11436,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12214,37 +11554,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12346,40 +11680,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Note heading",
-          "startsNewBlock": true
+          "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12457,31 +11785,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12567,34 +11889,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12680,34 +11996,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12801,37 +12111,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -12917,34 +12221,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13038,37 +12336,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13162,37 +12454,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13294,40 +12580,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Detail heading",
-          "startsNewBlock": true
+          "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13413,34 +12693,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13534,37 +12808,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13658,37 +12926,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13790,40 +13052,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Subsection i",
-          "startsNewBlock": true
+          "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -13917,37 +13173,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -14049,40 +13299,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Section A",
-          "startsNewBlock": true
+          "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -14184,40 +13428,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"
@@ -14327,43 +13565,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Heading level 2.",
-          "startsNewBlock": true
+          "ssml": "Heading level 2."
         },
         {
           "ssml": "Section A"
         },
         {
-          "ssml": "Heading level 3.",
-          "startsNewBlock": true
+          "ssml": "Heading level 3."
         },
         {
           "ssml": "Subsection i"
         },
         {
-          "ssml": "Heading level 4.",
-          "startsNewBlock": true
+          "ssml": "Heading level 4."
         },
         {
           "ssml": "Detail heading"
         },
         {
-          "ssml": "Heading level 5.",
-          "startsNewBlock": true
+          "ssml": "Heading level 5."
         },
         {
           "ssml": "Note heading"
         },
         {
-          "ssml": "Heading level 6.",
-          "startsNewBlock": true
+          "ssml": "Heading level 6."
         },
         {
           "ssml": "Aside heading"

--- a/fixtures/hidden-aria-hidden-html-native/utterances.json
+++ b/fixtures/hidden-aria-hidden-html-native/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Before the hidden content.",
-          "startsNewBlock": true
+          "plain": "Before the hidden content."
         },
         {
-          "plain": "After the hidden content.",
-          "startsNewBlock": true
+          "plain": "After the hidden content."
         }
       ]
     },
@@ -25,12 +23,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Before the hidden content.",
-          "startsNewBlock": true
+          "ssml": "Before the hidden content."
         },
         {
-          "ssml": "After the hidden content.",
-          "startsNewBlock": true
+          "ssml": "After the hidden content."
         }
       ]
     }

--- a/fixtures/hidden-attribute-html-native/utterances.json
+++ b/fixtures/hidden-attribute-html-native/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Before the hidden content.",
-          "startsNewBlock": true
+          "plain": "Before the hidden content."
         },
         {
-          "plain": "After the hidden content.",
-          "startsNewBlock": true
+          "plain": "After the hidden content."
         }
       ]
     },
@@ -25,12 +23,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Before the hidden content.",
-          "startsNewBlock": true
+          "ssml": "Before the hidden content."
         },
         {
-          "ssml": "After the hidden content.",
-          "startsNewBlock": true
+          "ssml": "After the hidden content."
         }
       ]
     }

--- a/fixtures/image-alt-html-native/utterances.json
+++ b/fixtures/image-alt-html-native/utterances.json
@@ -75,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "Alternative text using the alt attribute"
@@ -303,8 +302,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "Alternative text using the alt attribute"

--- a/fixtures/image-decorative-empty-alt/utterances.json
+++ b/fixtures/image-decorative-empty-alt/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Before the divider.",
-          "startsNewBlock": true
+          "plain": "Before the divider."
         },
         {
-          "plain": "After the divider.",
-          "startsNewBlock": true
+          "plain": "After the divider."
         }
       ]
     },
@@ -25,12 +23,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Before the divider.",
-          "startsNewBlock": true
+          "ssml": "Before the divider."
         },
         {
-          "ssml": "After the divider.",
-          "startsNewBlock": true
+          "ssml": "After the divider."
         }
       ]
     }

--- a/fixtures/image-decorative-role-presentation/utterances.json
+++ b/fixtures/image-decorative-role-presentation/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Before the divider.",
-          "startsNewBlock": true
+          "plain": "Before the divider."
         },
         {
-          "plain": "After the divider.",
-          "startsNewBlock": true
+          "plain": "After the divider."
         }
       ]
     },
@@ -25,12 +23,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Before the divider.",
-          "startsNewBlock": true
+          "ssml": "Before the divider."
         },
         {
-          "ssml": "After the divider.",
-          "startsNewBlock": true
+          "ssml": "After the divider."
         }
       ]
     }

--- a/fixtures/image-role-aria/utterances.json
+++ b/fixtures/image-role-aria/utterances.json
@@ -75,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Image.",
-          "startsNewBlock": true
+          "plain": "Image."
         },
         {
           "plain": "Rating: 4 out of 5 stars"
@@ -303,8 +302,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Image.",
-          "startsNewBlock": true
+          "ssml": "Image."
         },
         {
           "ssml": "Rating: 4 out of 5 stars"

--- a/fixtures/index-epub-type/utterances.json
+++ b/fixtures/index-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Fresnel lens",
-          "startsNewBlock": true
+          "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         }
       ]
     },
@@ -80,15 +78,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         },
         {
           "plain": "End of the index."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         },
         {
           "plain": "End of the list."
@@ -244,8 +238,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "Start of the list."
@@ -254,8 +247,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -414,8 +404,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "List item."
@@ -424,8 +413,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -506,8 +494,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -516,8 +503,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -606,8 +592,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "Start of the list."
@@ -619,8 +604,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -641,12 +625,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Fresnel lens",
-          "startsNewBlock": true
+          "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         }
       ]
     },
@@ -713,15 +695,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         },
         {
           "ssml": "End of the index."
@@ -791,15 +771,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         },
         {
           "ssml": "End of the list."
@@ -877,8 +855,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "Start of the list."
@@ -887,8 +864,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         },
         {
           "ssml": "End of the list."
@@ -961,15 +937,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"
@@ -1047,8 +1021,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "List item."
@@ -1057,8 +1030,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"
@@ -1139,8 +1111,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1149,8 +1120,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"
@@ -1239,8 +1209,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "Start of the list."
@@ -1252,8 +1221,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"

--- a/fixtures/index-role-aria/utterances.json
+++ b/fixtures/index-role-aria/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Fresnel lens",
-          "startsNewBlock": true
+          "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         }
       ]
     },
@@ -80,15 +78,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         },
         {
           "plain": "End of the index."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         },
         {
           "plain": "End of the list."
@@ -244,8 +238,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "Start of the list."
@@ -254,8 +247,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "Keepers",
-          "startsNewBlock": true
+          "plain": "Keepers"
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -414,8 +404,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "List item."
@@ -424,8 +413,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -506,8 +494,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -516,8 +503,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -606,8 +592,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the index.",
-          "startsNewBlock": true
+          "plain": "Start of the index."
         },
         {
           "plain": "Start of the list."
@@ -619,8 +604,7 @@
           "plain": "Fresnel lens"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Keepers"
@@ -641,12 +625,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Fresnel lens",
-          "startsNewBlock": true
+          "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         }
       ]
     },
@@ -713,15 +695,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         },
         {
           "ssml": "End of the index."
@@ -791,15 +771,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         },
         {
           "ssml": "End of the list."
@@ -877,8 +855,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "Start of the list."
@@ -887,8 +864,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "Keepers",
-          "startsNewBlock": true
+          "ssml": "Keepers"
         },
         {
           "ssml": "End of the list."
@@ -961,15 +937,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"
@@ -1047,8 +1021,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "List item."
@@ -1057,8 +1030,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"
@@ -1139,8 +1111,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1149,8 +1120,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"
@@ -1239,8 +1209,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the index.",
-          "startsNewBlock": true
+          "ssml": "Start of the index."
         },
         {
           "ssml": "Start of the list."
@@ -1252,8 +1221,7 @@
           "ssml": "Fresnel lens"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Keepers"

--- a/fixtures/introduction-epub-type/utterances.json
+++ b/fixtures/introduction-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "This work explores the history of coastal lighthouses.",
-          "startsNewBlock": true
+          "plain": "This work explores the history of coastal lighthouses."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the introduction.",
-          "startsNewBlock": true
+          "plain": "Start of the introduction."
         },
         {
           "plain": "This work explores the history of coastal lighthouses."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This work explores the history of coastal lighthouses.",
-          "startsNewBlock": true
+          "ssml": "This work explores the history of coastal lighthouses."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the introduction.",
-          "startsNewBlock": true
+          "ssml": "Start of the introduction."
         },
         {
           "ssml": "This work explores the history of coastal lighthouses."

--- a/fixtures/introduction-role-aria/utterances.json
+++ b/fixtures/introduction-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "This work explores the history of coastal lighthouses.",
-          "startsNewBlock": true
+          "plain": "This work explores the history of coastal lighthouses."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the introduction.",
-          "startsNewBlock": true
+          "plain": "Start of the introduction."
         },
         {
           "plain": "This work explores the history of coastal lighthouses."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This work explores the history of coastal lighthouses.",
-          "startsNewBlock": true
+          "ssml": "This work explores the history of coastal lighthouses."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the introduction.",
-          "startsNewBlock": true
+          "ssml": "Start of the introduction."
         },
         {
           "ssml": "This work explores the history of coastal lighthouses."

--- a/fixtures/landmarks-epub-type/utterances.json
+++ b/fixtures/landmarks-epub-type/utterances.json
@@ -8,16 +8,13 @@
       ],
       "utterances": [
         {
-          "plain": "Cover",
-          "startsNewBlock": true
+          "plain": "Cover"
         },
         {
-          "plain": "Table of Contents",
-          "startsNewBlock": true
+          "plain": "Table of Contents"
         },
         {
-          "plain": "Start of Content",
-          "startsNewBlock": true
+          "plain": "Start of Content"
         }
       ]
     },
@@ -87,16 +84,13 @@
           "plain": "Start of the landmarks."
         },
         {
-          "plain": "Cover",
-          "startsNewBlock": true
+          "plain": "Cover"
         },
         {
-          "plain": "Table of Contents",
-          "startsNewBlock": true
+          "plain": "Table of Contents"
         },
         {
-          "plain": "Start of Content",
-          "startsNewBlock": true
+          "plain": "Start of Content"
         },
         {
           "plain": "End of the landmarks."
@@ -166,19 +160,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Cover"
         },
         {
-          "plain": "Table of Contents",
-          "startsNewBlock": true
+          "plain": "Table of Contents"
         },
         {
-          "plain": "Start of Content",
-          "startsNewBlock": true
+          "plain": "Start of Content"
         },
         {
           "plain": "End of the list."
@@ -259,19 +250,16 @@
           "plain": "Start of the landmarks."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Cover"
         },
         {
-          "plain": "Table of Contents",
-          "startsNewBlock": true
+          "plain": "Table of Contents"
         },
         {
-          "plain": "Start of Content",
-          "startsNewBlock": true
+          "plain": "Start of Content"
         },
         {
           "plain": "End of the list."
@@ -344,22 +332,19 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Cover"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Table of Contents"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Start of Content"
@@ -438,106 +423,6 @@
       "utterances": [
         {
           "plain": "Start of the landmarks."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Cover"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Table of Contents"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Start of Content"
-        },
-        {
-          "plain": "End of the landmarks."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -546,15 +431,109 @@
           "plain": "Cover"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Table of Contents"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Start of Content"
+        },
+        {
+          "plain": "End of the landmarks."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Cover"
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Table of Contents"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Start of Content"
@@ -646,8 +625,7 @@
           "plain": "Start of the landmarks."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -656,15 +634,13 @@
           "plain": "Cover"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Table of Contents"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Start of Content"
@@ -1362,16 +1338,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Cover",
-          "startsNewBlock": true
+          "ssml": "Cover"
         },
         {
-          "ssml": "Table of Contents",
-          "startsNewBlock": true
+          "ssml": "Table of Contents"
         },
         {
-          "ssml": "Start of Content",
-          "startsNewBlock": true
+          "ssml": "Start of Content"
         }
       ]
     },
@@ -1441,16 +1414,13 @@
           "ssml": "Start of the landmarks."
         },
         {
-          "ssml": "Cover",
-          "startsNewBlock": true
+          "ssml": "Cover"
         },
         {
-          "ssml": "Table of Contents",
-          "startsNewBlock": true
+          "ssml": "Table of Contents"
         },
         {
-          "ssml": "Start of Content",
-          "startsNewBlock": true
+          "ssml": "Start of Content"
         },
         {
           "ssml": "End of the landmarks."
@@ -1520,19 +1490,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Cover"
         },
         {
-          "ssml": "Table of Contents",
-          "startsNewBlock": true
+          "ssml": "Table of Contents"
         },
         {
-          "ssml": "Start of Content",
-          "startsNewBlock": true
+          "ssml": "Start of Content"
         },
         {
           "ssml": "End of the list."
@@ -1613,19 +1580,16 @@
           "ssml": "Start of the landmarks."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Cover"
         },
         {
-          "ssml": "Table of Contents",
-          "startsNewBlock": true
+          "ssml": "Table of Contents"
         },
         {
-          "ssml": "Start of Content",
-          "startsNewBlock": true
+          "ssml": "Start of Content"
         },
         {
           "ssml": "End of the list."
@@ -1698,22 +1662,19 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Cover"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Table of Contents"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Start of Content"
@@ -1792,106 +1753,6 @@
       "utterances": [
         {
           "ssml": "Start of the landmarks."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Cover"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Table of Contents"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Start of Content"
-        },
-        {
-          "ssml": "End of the landmarks."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1900,15 +1761,109 @@
           "ssml": "Cover"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Table of Contents"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Start of Content"
+        },
+        {
+          "ssml": "End of the landmarks."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Cover"
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Table of Contents"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Start of Content"
@@ -2000,8 +1955,7 @@
           "ssml": "Start of the landmarks."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -2010,15 +1964,13 @@
           "ssml": "Cover"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Table of Contents"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Start of Content"

--- a/fixtures/language-block/utterances.json
+++ b/fixtures/language-block/utterances.json
@@ -9,13 +9,11 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "Hello.",
-          "startsNewBlock": true
+          "plain": "Hello."
         },
         {
           "language": "fr",
-          "plain": "Bonjour.",
-          "startsNewBlock": true
+          "plain": "Bonjour."
         }
       ]
     },
@@ -33,12 +31,10 @@
       ],
       "utterances": [
         {
-          "plain": "Hello.",
-          "startsNewBlock": true
+          "plain": "Hello."
         },
         {
-          "plain": "Bonjour.",
-          "startsNewBlock": true
+          "plain": "Bonjour."
         }
       ]
     },
@@ -51,13 +47,11 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "Hello.",
-          "startsNewBlock": true
+          "ssml": "Hello."
         },
         {
           "language": "fr",
-          "ssml": "Bonjour.",
-          "startsNewBlock": true
+          "ssml": "Bonjour."
         }
       ]
     },
@@ -75,12 +69,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Hello.",
-          "startsNewBlock": true
+          "ssml": "Hello."
         },
         {
-          "ssml": "Bonjour.",
-          "startsNewBlock": true
+          "ssml": "Bonjour."
         }
       ]
     }

--- a/fixtures/language-document/utterances.json
+++ b/fixtures/language-document/utterances.json
@@ -9,8 +9,7 @@
       "utterances": [
         {
           "language": "fr",
-          "plain": "Bonjour, comment allez-vous ?",
-          "startsNewBlock": true
+          "plain": "Bonjour, comment allez-vous ?"
         }
       ]
     },
@@ -28,8 +27,7 @@
       ],
       "utterances": [
         {
-          "plain": "Bonjour, comment allez-vous ?",
-          "startsNewBlock": true
+          "plain": "Bonjour, comment allez-vous ?"
         }
       ]
     },
@@ -42,8 +40,7 @@
       "utterances": [
         {
           "language": "fr",
-          "ssml": "Bonjour, comment allez-vous ?",
-          "startsNewBlock": true
+          "ssml": "Bonjour, comment allez-vous ?"
         }
       ]
     },
@@ -61,8 +58,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Bonjour, comment allez-vous ?",
-          "startsNewBlock": true
+          "ssml": "Bonjour, comment allez-vous ?"
         }
       ]
     }

--- a/fixtures/language-inline-lang-attribute/utterances.json
+++ b/fixtures/language-inline-lang-attribute/utterances.json
@@ -9,8 +9,7 @@
       "utterances": [
         {
           "plain": "Hello",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         },
         {
           "plain": "bonjour.",
@@ -33,8 +32,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "Hello bonjour.",
-          "startsNewBlock": true
+          "plain": "Hello bonjour."
         }
       ]
     },
@@ -52,8 +50,7 @@
       ],
       "utterances": [
         {
-          "plain": "Hello bonjour.",
-          "startsNewBlock": true
+          "plain": "Hello bonjour."
         }
       ]
     },
@@ -66,8 +63,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "Hello <lang xml:lang=\"fr\">bonjour</lang>.",
-          "startsNewBlock": true
+          "ssml": "Hello <lang xml:lang=\"fr\">bonjour</lang>."
         }
       ]
     },
@@ -86,8 +82,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "Hello bonjour.",
-          "startsNewBlock": true
+          "ssml": "Hello bonjour."
         }
       ]
     },
@@ -105,8 +100,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Hello bonjour.",
-          "startsNewBlock": true
+          "ssml": "Hello bonjour."
         }
       ]
     }

--- a/fixtures/language-inline-nested/utterances.json
+++ b/fixtures/language-inline-nested/utterances.json
@@ -9,8 +9,7 @@
       "utterances": [
         {
           "plain": "Start",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         },
         {
           "plain": "middle",
@@ -45,8 +44,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "Start middle nested end after.",
-          "startsNewBlock": true
+          "plain": "Start middle nested end after."
         }
       ]
     },
@@ -64,8 +62,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start middle nested end after.",
-          "startsNewBlock": true
+          "plain": "Start middle nested end after."
         }
       ]
     },
@@ -78,8 +75,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "Start <lang xml:lang=\"fr\">middle </lang><lang xml:lang=\"es\">nested</lang><lang xml:lang=\"fr\"> end</lang> after.",
-          "startsNewBlock": true
+          "ssml": "Start <lang xml:lang=\"fr\">middle </lang><lang xml:lang=\"es\">nested</lang><lang xml:lang=\"fr\"> end</lang> after."
         }
       ]
     },
@@ -98,8 +94,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "Start middle nested end after.",
-          "startsNewBlock": true
+          "ssml": "Start middle nested end after."
         }
       ]
     },
@@ -117,8 +112,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start middle nested end after.",
-          "startsNewBlock": true
+          "ssml": "Start middle nested end after."
         }
       ]
     }

--- a/fixtures/language-inline-repeated/utterances.json
+++ b/fixtures/language-inline-repeated/utterances.json
@@ -9,8 +9,7 @@
       "utterances": [
         {
           "plain": "One",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         },
         {
           "plain": "deux",
@@ -45,8 +44,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "One deux three quatre five.",
-          "startsNewBlock": true
+          "plain": "One deux three quatre five."
         }
       ]
     },
@@ -64,8 +62,7 @@
       ],
       "utterances": [
         {
-          "plain": "One deux three quatre five.",
-          "startsNewBlock": true
+          "plain": "One deux three quatre five."
         }
       ]
     },
@@ -78,8 +75,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "One <lang xml:lang=\"fr\">deux</lang> three <lang xml:lang=\"fr\">quatre</lang> five.",
-          "startsNewBlock": true
+          "ssml": "One <lang xml:lang=\"fr\">deux</lang> three <lang xml:lang=\"fr\">quatre</lang> five."
         }
       ]
     },
@@ -98,8 +94,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "One deux three quatre five.",
-          "startsNewBlock": true
+          "ssml": "One deux three quatre five."
         }
       ]
     },
@@ -117,8 +112,7 @@
       ],
       "utterances": [
         {
-          "ssml": "One deux three quatre five.",
-          "startsNewBlock": true
+          "ssml": "One deux three quatre five."
         }
       ]
     }

--- a/fixtures/language-inline-two-languages/utterances.json
+++ b/fixtures/language-inline-two-languages/utterances.json
@@ -9,8 +9,7 @@
       "utterances": [
         {
           "plain": "Hello",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         },
         {
           "plain": "bonjour",
@@ -45,8 +44,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "Hello bonjour and hola there.",
-          "startsNewBlock": true
+          "plain": "Hello bonjour and hola there."
         }
       ]
     },
@@ -64,8 +62,7 @@
       ],
       "utterances": [
         {
-          "plain": "Hello bonjour and hola there.",
-          "startsNewBlock": true
+          "plain": "Hello bonjour and hola there."
         }
       ]
     },
@@ -78,8 +75,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "Hello <lang xml:lang=\"fr\">bonjour</lang> and <lang xml:lang=\"es\">hola</lang> there.",
-          "startsNewBlock": true
+          "ssml": "Hello <lang xml:lang=\"fr\">bonjour</lang> and <lang xml:lang=\"es\">hola</lang> there."
         }
       ]
     },
@@ -98,8 +94,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "Hello bonjour and hola there.",
-          "startsNewBlock": true
+          "ssml": "Hello bonjour and hola there."
         }
       ]
     },
@@ -117,8 +112,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Hello bonjour and hola there.",
-          "startsNewBlock": true
+          "ssml": "Hello bonjour and hola there."
         }
       ]
     }

--- a/fixtures/list-html-native/utterances.json
+++ b/fixtures/list-html-native/utterances.json
@@ -8,16 +8,13 @@
       ],
       "utterances": [
         {
-          "plain": "First item",
-          "startsNewBlock": true
+          "plain": "First item"
         },
         {
-          "plain": "Second item",
-          "startsNewBlock": true
+          "plain": "Second item"
         },
         {
-          "plain": "Third item",
-          "startsNewBlock": true
+          "plain": "Third item"
         }
       ]
     },
@@ -84,19 +81,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "First item"
         },
         {
-          "plain": "Second item",
-          "startsNewBlock": true
+          "plain": "Second item"
         },
         {
-          "plain": "Third item",
-          "startsNewBlock": true
+          "plain": "Third item"
         },
         {
           "plain": "End of the list."
@@ -166,22 +160,19 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "First item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Second item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Third item"
@@ -259,8 +250,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -269,15 +259,13 @@
           "plain": "First item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Second item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Third item"
@@ -295,16 +283,13 @@
       ],
       "utterances": [
         {
-          "ssml": "First item",
-          "startsNewBlock": true
+          "ssml": "First item"
         },
         {
-          "ssml": "Second item",
-          "startsNewBlock": true
+          "ssml": "Second item"
         },
         {
-          "ssml": "Third item",
-          "startsNewBlock": true
+          "ssml": "Third item"
         }
       ]
     },
@@ -371,19 +356,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "First item"
         },
         {
-          "ssml": "Second item",
-          "startsNewBlock": true
+          "ssml": "Second item"
         },
         {
-          "ssml": "Third item",
-          "startsNewBlock": true
+          "ssml": "Third item"
         },
         {
           "ssml": "End of the list."
@@ -453,22 +435,19 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "First item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Second item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Third item"
@@ -546,8 +525,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -556,15 +534,13 @@
           "ssml": "First item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Second item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Third item"

--- a/fixtures/list-role-aria/utterances.json
+++ b/fixtures/list-role-aria/utterances.json
@@ -8,16 +8,13 @@
       ],
       "utterances": [
         {
-          "plain": "First item",
-          "startsNewBlock": true
+          "plain": "First item"
         },
         {
-          "plain": "Second item",
-          "startsNewBlock": true
+          "plain": "Second item"
         },
         {
-          "plain": "Third item",
-          "startsNewBlock": true
+          "plain": "Third item"
         }
       ]
     },
@@ -84,19 +81,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "First item"
         },
         {
-          "plain": "Second item",
-          "startsNewBlock": true
+          "plain": "Second item"
         },
         {
-          "plain": "Third item",
-          "startsNewBlock": true
+          "plain": "Third item"
         },
         {
           "plain": "End of the list."
@@ -166,22 +160,19 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "First item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Second item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Third item"
@@ -259,8 +250,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -269,15 +259,13 @@
           "plain": "First item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Second item"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Third item"
@@ -295,16 +283,13 @@
       ],
       "utterances": [
         {
-          "ssml": "First item",
-          "startsNewBlock": true
+          "ssml": "First item"
         },
         {
-          "ssml": "Second item",
-          "startsNewBlock": true
+          "ssml": "Second item"
         },
         {
-          "ssml": "Third item",
-          "startsNewBlock": true
+          "ssml": "Third item"
         }
       ]
     },
@@ -371,19 +356,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "First item"
         },
         {
-          "ssml": "Second item",
-          "startsNewBlock": true
+          "ssml": "Second item"
         },
         {
-          "ssml": "Third item",
-          "startsNewBlock": true
+          "ssml": "Third item"
         },
         {
           "ssml": "End of the list."
@@ -453,22 +435,19 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "First item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Second item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Third item"
@@ -546,8 +525,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -556,15 +534,13 @@
           "ssml": "First item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Second item"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Third item"

--- a/fixtures/loa-epub-type/utterances.json
+++ b/fixtures/loa-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Audio 1. Foghorn recording",
-          "startsNewBlock": true
+          "plain": "Audio 1. Foghorn recording"
         },
         {
-          "plain": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "plain": "Audio 2. Keeper's log reading"
         }
       ]
     },
@@ -83,12 +81,10 @@
           "plain": "Start of the list of audio clips."
         },
         {
-          "plain": "Audio 1. Foghorn recording",
-          "startsNewBlock": true
+          "plain": "Audio 1. Foghorn recording"
         },
         {
-          "plain": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "plain": "Audio 2. Keeper's log reading"
         },
         {
           "plain": "End of the list of audio clips."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Audio 1. Foghorn recording"
         },
         {
-          "plain": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "plain": "Audio 2. Keeper's log reading"
         },
         {
           "plain": "End of the list."
@@ -247,15 +241,13 @@
           "plain": "Start of the list of audio clips."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Audio 1. Foghorn recording"
         },
         {
-          "plain": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "plain": "Audio 2. Keeper's log reading"
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Audio 1. Foghorn recording"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Audio 2. Keeper's log reading"
@@ -415,99 +405,6 @@
       "utterances": [
         {
           "plain": "Start of the list of audio clips."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Audio 1. Foghorn recording"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Audio 2. Keeper's log reading"
-        },
-        {
-          "plain": "End of the list of audio clips."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -516,8 +413,97 @@
           "plain": "Audio 1. Foghorn recording"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Audio 2. Keeper's log reading"
+        },
+        {
+          "plain": "End of the list of audio clips."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Audio 1. Foghorn recording"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Audio 2. Keeper's log reading"
@@ -609,8 +595,7 @@
           "plain": "Start of the list of audio clips."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -619,8 +604,7 @@
           "plain": "Audio 1. Foghorn recording"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Audio 2. Keeper's log reading"
@@ -1318,12 +1302,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Audio 1. Foghorn recording",
-          "startsNewBlock": true
+          "ssml": "Audio 1. Foghorn recording"
         },
         {
-          "ssml": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "ssml": "Audio 2. Keeper's log reading"
         }
       ]
     },
@@ -1393,12 +1375,10 @@
           "ssml": "Start of the list of audio clips."
         },
         {
-          "ssml": "Audio 1. Foghorn recording",
-          "startsNewBlock": true
+          "ssml": "Audio 1. Foghorn recording"
         },
         {
-          "ssml": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "ssml": "Audio 2. Keeper's log reading"
         },
         {
           "ssml": "End of the list of audio clips."
@@ -1468,15 +1448,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Audio 1. Foghorn recording"
         },
         {
-          "ssml": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "ssml": "Audio 2. Keeper's log reading"
         },
         {
           "ssml": "End of the list."
@@ -1557,15 +1535,13 @@
           "ssml": "Start of the list of audio clips."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Audio 1. Foghorn recording"
         },
         {
-          "ssml": "Audio 2. Keeper's log reading",
-          "startsNewBlock": true
+          "ssml": "Audio 2. Keeper's log reading"
         },
         {
           "ssml": "End of the list."
@@ -1638,15 +1614,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Audio 1. Foghorn recording"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Audio 2. Keeper's log reading"
@@ -1725,99 +1699,6 @@
       "utterances": [
         {
           "ssml": "Start of the list of audio clips."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Audio 1. Foghorn recording"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Audio 2. Keeper's log reading"
-        },
-        {
-          "ssml": "End of the list of audio clips."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1826,8 +1707,97 @@
           "ssml": "Audio 1. Foghorn recording"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Audio 2. Keeper's log reading"
+        },
+        {
+          "ssml": "End of the list of audio clips."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Audio 1. Foghorn recording"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Audio 2. Keeper's log reading"
@@ -1919,8 +1889,7 @@
           "ssml": "Start of the list of audio clips."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1929,8 +1898,7 @@
           "ssml": "Audio 1. Foghorn recording"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Audio 2. Keeper's log reading"

--- a/fixtures/loi-epub-type/utterances.json
+++ b/fixtures/loi-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Figure 1. Lighthouse cross-section",
-          "startsNewBlock": true
+          "plain": "Figure 1. Lighthouse cross-section"
         },
         {
-          "plain": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "plain": "Figure 2. Fresnel lens diagram"
         }
       ]
     },
@@ -83,12 +81,10 @@
           "plain": "Start of the list of illustrations."
         },
         {
-          "plain": "Figure 1. Lighthouse cross-section",
-          "startsNewBlock": true
+          "plain": "Figure 1. Lighthouse cross-section"
         },
         {
-          "plain": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "plain": "Figure 2. Fresnel lens diagram"
         },
         {
           "plain": "End of the list of illustrations."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Figure 1. Lighthouse cross-section"
         },
         {
-          "plain": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "plain": "Figure 2. Fresnel lens diagram"
         },
         {
           "plain": "End of the list."
@@ -247,15 +241,13 @@
           "plain": "Start of the list of illustrations."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Figure 1. Lighthouse cross-section"
         },
         {
-          "plain": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "plain": "Figure 2. Fresnel lens diagram"
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Figure 1. Lighthouse cross-section"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Figure 2. Fresnel lens diagram"
@@ -415,99 +405,6 @@
       "utterances": [
         {
           "plain": "Start of the list of illustrations."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Figure 1. Lighthouse cross-section"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Figure 2. Fresnel lens diagram"
-        },
-        {
-          "plain": "End of the list of illustrations."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -516,8 +413,97 @@
           "plain": "Figure 1. Lighthouse cross-section"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Figure 2. Fresnel lens diagram"
+        },
+        {
+          "plain": "End of the list of illustrations."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Figure 1. Lighthouse cross-section"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Figure 2. Fresnel lens diagram"
@@ -609,8 +595,7 @@
           "plain": "Start of the list of illustrations."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -619,8 +604,7 @@
           "plain": "Figure 1. Lighthouse cross-section"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Figure 2. Fresnel lens diagram"
@@ -1318,12 +1302,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Figure 1. Lighthouse cross-section",
-          "startsNewBlock": true
+          "ssml": "Figure 1. Lighthouse cross-section"
         },
         {
-          "ssml": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "ssml": "Figure 2. Fresnel lens diagram"
         }
       ]
     },
@@ -1393,12 +1375,10 @@
           "ssml": "Start of the list of illustrations."
         },
         {
-          "ssml": "Figure 1. Lighthouse cross-section",
-          "startsNewBlock": true
+          "ssml": "Figure 1. Lighthouse cross-section"
         },
         {
-          "ssml": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "ssml": "Figure 2. Fresnel lens diagram"
         },
         {
           "ssml": "End of the list of illustrations."
@@ -1468,15 +1448,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Figure 1. Lighthouse cross-section"
         },
         {
-          "ssml": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "ssml": "Figure 2. Fresnel lens diagram"
         },
         {
           "ssml": "End of the list."
@@ -1557,15 +1535,13 @@
           "ssml": "Start of the list of illustrations."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Figure 1. Lighthouse cross-section"
         },
         {
-          "ssml": "Figure 2. Fresnel lens diagram",
-          "startsNewBlock": true
+          "ssml": "Figure 2. Fresnel lens diagram"
         },
         {
           "ssml": "End of the list."
@@ -1638,15 +1614,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Figure 1. Lighthouse cross-section"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Figure 2. Fresnel lens diagram"
@@ -1725,99 +1699,6 @@
       "utterances": [
         {
           "ssml": "Start of the list of illustrations."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Figure 1. Lighthouse cross-section"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Figure 2. Fresnel lens diagram"
-        },
-        {
-          "ssml": "End of the list of illustrations."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1826,8 +1707,97 @@
           "ssml": "Figure 1. Lighthouse cross-section"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Figure 2. Fresnel lens diagram"
+        },
+        {
+          "ssml": "End of the list of illustrations."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Figure 1. Lighthouse cross-section"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Figure 2. Fresnel lens diagram"
@@ -1919,8 +1889,7 @@
           "ssml": "Start of the list of illustrations."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1929,8 +1898,7 @@
           "ssml": "Figure 1. Lighthouse cross-section"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Figure 2. Fresnel lens diagram"

--- a/fixtures/lot-epub-type/utterances.json
+++ b/fixtures/lot-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Table 1. Lighthouse construction dates",
-          "startsNewBlock": true
+          "plain": "Table 1. Lighthouse construction dates"
         },
         {
-          "plain": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "plain": "Table 2. Keeper staffing by decade"
         }
       ]
     },
@@ -83,12 +81,10 @@
           "plain": "Start of the list of tables."
         },
         {
-          "plain": "Table 1. Lighthouse construction dates",
-          "startsNewBlock": true
+          "plain": "Table 1. Lighthouse construction dates"
         },
         {
-          "plain": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "plain": "Table 2. Keeper staffing by decade"
         },
         {
           "plain": "End of the list of tables."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Table 1. Lighthouse construction dates"
         },
         {
-          "plain": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "plain": "Table 2. Keeper staffing by decade"
         },
         {
           "plain": "End of the list."
@@ -247,15 +241,13 @@
           "plain": "Start of the list of tables."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Table 1. Lighthouse construction dates"
         },
         {
-          "plain": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "plain": "Table 2. Keeper staffing by decade"
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Table 1. Lighthouse construction dates"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Table 2. Keeper staffing by decade"
@@ -415,99 +405,6 @@
       "utterances": [
         {
           "plain": "Start of the list of tables."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Table 1. Lighthouse construction dates"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Table 2. Keeper staffing by decade"
-        },
-        {
-          "plain": "End of the list of tables."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -516,8 +413,97 @@
           "plain": "Table 1. Lighthouse construction dates"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Table 2. Keeper staffing by decade"
+        },
+        {
+          "plain": "End of the list of tables."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Table 1. Lighthouse construction dates"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Table 2. Keeper staffing by decade"
@@ -609,8 +595,7 @@
           "plain": "Start of the list of tables."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -619,8 +604,7 @@
           "plain": "Table 1. Lighthouse construction dates"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Table 2. Keeper staffing by decade"
@@ -1318,12 +1302,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Table 1. Lighthouse construction dates",
-          "startsNewBlock": true
+          "ssml": "Table 1. Lighthouse construction dates"
         },
         {
-          "ssml": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "ssml": "Table 2. Keeper staffing by decade"
         }
       ]
     },
@@ -1393,12 +1375,10 @@
           "ssml": "Start of the list of tables."
         },
         {
-          "ssml": "Table 1. Lighthouse construction dates",
-          "startsNewBlock": true
+          "ssml": "Table 1. Lighthouse construction dates"
         },
         {
-          "ssml": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "ssml": "Table 2. Keeper staffing by decade"
         },
         {
           "ssml": "End of the list of tables."
@@ -1468,15 +1448,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Table 1. Lighthouse construction dates"
         },
         {
-          "ssml": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "ssml": "Table 2. Keeper staffing by decade"
         },
         {
           "ssml": "End of the list."
@@ -1557,15 +1535,13 @@
           "ssml": "Start of the list of tables."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Table 1. Lighthouse construction dates"
         },
         {
-          "ssml": "Table 2. Keeper staffing by decade",
-          "startsNewBlock": true
+          "ssml": "Table 2. Keeper staffing by decade"
         },
         {
           "ssml": "End of the list."
@@ -1638,15 +1614,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Table 1. Lighthouse construction dates"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Table 2. Keeper staffing by decade"
@@ -1725,99 +1699,6 @@
       "utterances": [
         {
           "ssml": "Start of the list of tables."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Table 1. Lighthouse construction dates"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Table 2. Keeper staffing by decade"
-        },
-        {
-          "ssml": "End of the list of tables."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1826,8 +1707,97 @@
           "ssml": "Table 1. Lighthouse construction dates"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Table 2. Keeper staffing by decade"
+        },
+        {
+          "ssml": "End of the list of tables."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Table 1. Lighthouse construction dates"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Table 2. Keeper staffing by decade"
@@ -1919,8 +1889,7 @@
           "ssml": "Start of the list of tables."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1929,8 +1898,7 @@
           "ssml": "Table 1. Lighthouse construction dates"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Table 2. Keeper staffing by decade"

--- a/fixtures/lov-epub-type/utterances.json
+++ b/fixtures/lov-epub-type/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Video 1. Lamp mechanism in motion",
-          "startsNewBlock": true
+          "plain": "Video 1. Lamp mechanism in motion"
         },
         {
-          "plain": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "plain": "Video 2. Automation retrofit"
         }
       ]
     },
@@ -83,12 +81,10 @@
           "plain": "Start of the list of video clips."
         },
         {
-          "plain": "Video 1. Lamp mechanism in motion",
-          "startsNewBlock": true
+          "plain": "Video 1. Lamp mechanism in motion"
         },
         {
-          "plain": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "plain": "Video 2. Automation retrofit"
         },
         {
           "plain": "End of the list of video clips."
@@ -158,15 +154,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Video 1. Lamp mechanism in motion"
         },
         {
-          "plain": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "plain": "Video 2. Automation retrofit"
         },
         {
           "plain": "End of the list."
@@ -247,15 +241,13 @@
           "plain": "Start of the list of video clips."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Video 1. Lamp mechanism in motion"
         },
         {
-          "plain": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "plain": "Video 2. Automation retrofit"
         },
         {
           "plain": "End of the list."
@@ -328,15 +320,13 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Video 1. Lamp mechanism in motion"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Video 2. Automation retrofit"
@@ -415,99 +405,6 @@
       "utterances": [
         {
           "plain": "Start of the list of video clips."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Video 1. Lamp mechanism in motion"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Video 2. Automation retrofit"
-        },
-        {
-          "plain": "End of the list of video clips."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -516,8 +413,97 @@
           "plain": "Video 1. Lamp mechanism in motion"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Video 2. Automation retrofit"
+        },
+        {
+          "plain": "End of the list of video clips."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Video 1. Lamp mechanism in motion"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Video 2. Automation retrofit"
@@ -609,8 +595,7 @@
           "plain": "Start of the list of video clips."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -619,8 +604,7 @@
           "plain": "Video 1. Lamp mechanism in motion"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Video 2. Automation retrofit"
@@ -1318,12 +1302,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Video 1. Lamp mechanism in motion",
-          "startsNewBlock": true
+          "ssml": "Video 1. Lamp mechanism in motion"
         },
         {
-          "ssml": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "ssml": "Video 2. Automation retrofit"
         }
       ]
     },
@@ -1393,12 +1375,10 @@
           "ssml": "Start of the list of video clips."
         },
         {
-          "ssml": "Video 1. Lamp mechanism in motion",
-          "startsNewBlock": true
+          "ssml": "Video 1. Lamp mechanism in motion"
         },
         {
-          "ssml": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "ssml": "Video 2. Automation retrofit"
         },
         {
           "ssml": "End of the list of video clips."
@@ -1468,15 +1448,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Video 1. Lamp mechanism in motion"
         },
         {
-          "ssml": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "ssml": "Video 2. Automation retrofit"
         },
         {
           "ssml": "End of the list."
@@ -1557,15 +1535,13 @@
           "ssml": "Start of the list of video clips."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Video 1. Lamp mechanism in motion"
         },
         {
-          "ssml": "Video 2. Automation retrofit",
-          "startsNewBlock": true
+          "ssml": "Video 2. Automation retrofit"
         },
         {
           "ssml": "End of the list."
@@ -1638,15 +1614,13 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Video 1. Lamp mechanism in motion"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Video 2. Automation retrofit"
@@ -1725,99 +1699,6 @@
       "utterances": [
         {
           "ssml": "Start of the list of video clips."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Video 1. Lamp mechanism in motion"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Video 2. Automation retrofit"
-        },
-        {
-          "ssml": "End of the list of video clips."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1826,8 +1707,97 @@
           "ssml": "Video 1. Lamp mechanism in motion"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Video 2. Automation retrofit"
+        },
+        {
+          "ssml": "End of the list of video clips."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Video 1. Lamp mechanism in motion"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Video 2. Automation retrofit"
@@ -1919,8 +1889,7 @@
           "ssml": "Start of the list of video clips."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1929,8 +1898,7 @@
           "ssml": "Video 1. Lamp mechanism in motion"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Video 2. Automation retrofit"

--- a/fixtures/notice-epub-type/utterances.json
+++ b/fixtures/notice-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Caution: the tower stairs are uneven.",
-          "startsNewBlock": true
+          "plain": "Caution: the tower stairs are uneven."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Notice.",
-          "startsNewBlock": true
+          "plain": "Notice."
         },
         {
           "plain": "Caution: the tower stairs are uneven."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Caution: the tower stairs are uneven.",
-          "startsNewBlock": true
+          "ssml": "Caution: the tower stairs are uneven."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Notice.",
-          "startsNewBlock": true
+          "ssml": "Notice."
         },
         {
           "ssml": "Caution: the tower stairs are uneven."

--- a/fixtures/notice-role-aria/utterances.json
+++ b/fixtures/notice-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Caution: the tower stairs are uneven.",
-          "startsNewBlock": true
+          "plain": "Caution: the tower stairs are uneven."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Notice.",
-          "startsNewBlock": true
+          "plain": "Notice."
         },
         {
           "plain": "Caution: the tower stairs are uneven."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Caution: the tower stairs are uneven.",
-          "startsNewBlock": true
+          "ssml": "Caution: the tower stairs are uneven."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Notice.",
-          "startsNewBlock": true
+          "ssml": "Notice."
         },
         {
           "ssml": "Caution: the tower stairs are uneven."

--- a/fixtures/pagebreak-epub-type/utterances.json
+++ b/fixtures/pagebreak-epub-type/utterances.json
@@ -12,8 +12,7 @@
         },
         {
           "language": "en",
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "5"
@@ -43,8 +42,7 @@
         },
         {
           "plain": "And the next pagebreak is in the middle 5 of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -60,8 +58,7 @@
           "plain": "4"
         },
         {
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "5"
@@ -81,8 +78,7 @@
           "plain": "4"
         },
         {
-          "plain": "And the next pagebreak is in the middle 5 of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle 5 of a sentence."
         }
       ]
     },
@@ -115,8 +111,7 @@
         },
         {
           "language": "en",
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "Pagebreak. 5."
@@ -155,8 +150,7 @@
         },
         {
           "plain": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -175,8 +169,7 @@
           "plain": "Pagebreak. 4."
         },
         {
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "Pagebreak. 5."
@@ -199,8 +192,7 @@
           "plain": "Pagebreak. 4."
         },
         {
-          "plain": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence."
         }
       ]
     },
@@ -314,8 +306,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     },
@@ -360,8 +351,7 @@
       ],
       "utterances": [
         {
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     },
@@ -377,8 +367,7 @@
         },
         {
           "language": "en",
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "5"
@@ -408,8 +397,7 @@
         },
         {
           "ssml": "And the next pagebreak is in the middle 5 of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -425,8 +413,7 @@
           "ssml": "4"
         },
         {
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "5"
@@ -446,8 +433,7 @@
           "ssml": "4"
         },
         {
-          "ssml": "And the next pagebreak is in the middle 5 of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle 5 of a sentence."
         }
       ]
     },
@@ -480,8 +466,7 @@
         },
         {
           "language": "en",
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "Pagebreak. 5."
@@ -520,8 +505,7 @@
         },
         {
           "ssml": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -540,8 +524,7 @@
           "ssml": "Pagebreak. 4."
         },
         {
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "Pagebreak. 5."
@@ -564,8 +547,7 @@
           "ssml": "Pagebreak. 4."
         },
         {
-          "ssml": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence."
         }
       ]
     },
@@ -679,8 +661,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     },
@@ -725,8 +706,7 @@
       ],
       "utterances": [
         {
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     }

--- a/fixtures/pagebreak-role-aria/utterances.json
+++ b/fixtures/pagebreak-role-aria/utterances.json
@@ -12,8 +12,7 @@
         },
         {
           "language": "en",
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "5"
@@ -43,8 +42,7 @@
         },
         {
           "plain": "And the next pagebreak is in the middle 5 of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -60,8 +58,7 @@
           "plain": "4"
         },
         {
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "5"
@@ -81,8 +78,7 @@
           "plain": "4"
         },
         {
-          "plain": "And the next pagebreak is in the middle 5 of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle 5 of a sentence."
         }
       ]
     },
@@ -115,8 +111,7 @@
         },
         {
           "language": "en",
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "Pagebreak. 5."
@@ -155,8 +150,7 @@
         },
         {
           "plain": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -175,8 +169,7 @@
           "plain": "Pagebreak. 4."
         },
         {
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "plain": "Pagebreak. 5."
@@ -199,8 +192,7 @@
           "plain": "Pagebreak. 4."
         },
         {
-          "plain": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence."
         }
       ]
     },
@@ -314,8 +306,7 @@
       "utterances": [
         {
           "language": "en",
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     },
@@ -360,8 +351,7 @@
       ],
       "utterances": [
         {
-          "plain": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "plain": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     },
@@ -377,8 +367,7 @@
         },
         {
           "language": "en",
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "5"
@@ -408,8 +397,7 @@
         },
         {
           "ssml": "And the next pagebreak is in the middle 5 of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -425,8 +413,7 @@
           "ssml": "4"
         },
         {
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "5"
@@ -446,8 +433,7 @@
           "ssml": "4"
         },
         {
-          "ssml": "And the next pagebreak is in the middle 5 of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle 5 of a sentence."
         }
       ]
     },
@@ -480,8 +466,7 @@
         },
         {
           "language": "en",
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "Pagebreak. 5."
@@ -520,8 +505,7 @@
         },
         {
           "ssml": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "language": "en",
-          "startsNewBlock": true
+          "language": "en"
         }
       ]
     },
@@ -540,8 +524,7 @@
           "ssml": "Pagebreak. 4."
         },
         {
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         },
         {
           "ssml": "Pagebreak. 5."
@@ -564,8 +547,7 @@
           "ssml": "Pagebreak. 4."
         },
         {
-          "ssml": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle Pagebreak. 5. of a sentence."
         }
       ]
     },
@@ -679,8 +661,7 @@
       "utterances": [
         {
           "language": "en",
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     },
@@ -725,8 +706,7 @@
       ],
       "utterances": [
         {
-          "ssml": "And the next pagebreak is in the middle of a sentence.",
-          "startsNewBlock": true
+          "ssml": "And the next pagebreak is in the middle of a sentence."
         }
       ]
     }

--- a/fixtures/pagelist-epub-type/utterances.json
+++ b/fixtures/pagelist-epub-type/utterances.json
@@ -8,16 +8,13 @@
       ],
       "utterances": [
         {
-          "plain": "Page 1",
-          "startsNewBlock": true
+          "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         }
       ]
     },
@@ -87,16 +84,13 @@
           "plain": "Start of the page list."
         },
         {
-          "plain": "Page 1",
-          "startsNewBlock": true
+          "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         },
         {
           "plain": "End of the page list."
@@ -166,19 +160,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         },
         {
           "plain": "End of the list."
@@ -259,19 +250,16 @@
           "plain": "Start of the page list."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         },
         {
           "plain": "End of the list."
@@ -344,22 +332,19 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 1"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 2"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 3"
@@ -438,106 +423,6 @@
       "utterances": [
         {
           "plain": "Start of the page list."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Page 1"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Page 2"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Page 3"
-        },
-        {
-          "plain": "End of the page list."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -546,15 +431,109 @@
           "plain": "Page 1"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 2"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Page 3"
+        },
+        {
+          "plain": "End of the page list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Page 1"
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Page 2"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Page 3"
@@ -646,8 +625,7 @@
           "plain": "Start of the page list."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -656,15 +634,13 @@
           "plain": "Page 1"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 2"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 3"
@@ -685,16 +661,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Page 1",
-          "startsNewBlock": true
+          "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         }
       ]
     },
@@ -764,16 +737,13 @@
           "ssml": "Start of the page list."
         },
         {
-          "ssml": "Page 1",
-          "startsNewBlock": true
+          "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         },
         {
           "ssml": "End of the page list."
@@ -843,19 +813,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         },
         {
           "ssml": "End of the list."
@@ -936,19 +903,16 @@
           "ssml": "Start of the page list."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         },
         {
           "ssml": "End of the list."
@@ -1021,22 +985,19 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 1"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 2"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 3"
@@ -1115,106 +1076,6 @@
       "utterances": [
         {
           "ssml": "Start of the page list."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Page 1"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Page 2"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Page 3"
-        },
-        {
-          "ssml": "End of the page list."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1223,15 +1084,109 @@
           "ssml": "Page 1"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 2"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Page 3"
+        },
+        {
+          "ssml": "End of the page list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Page 1"
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Page 2"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Page 3"
@@ -1323,8 +1278,7 @@
           "ssml": "Start of the page list."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1333,15 +1287,13 @@
           "ssml": "Page 1"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 2"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 3"

--- a/fixtures/pagelist-role-aria/utterances.json
+++ b/fixtures/pagelist-role-aria/utterances.json
@@ -8,16 +8,13 @@
       ],
       "utterances": [
         {
-          "plain": "Page 1",
-          "startsNewBlock": true
+          "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         }
       ]
     },
@@ -87,16 +84,13 @@
           "plain": "Start of the page list."
         },
         {
-          "plain": "Page 1",
-          "startsNewBlock": true
+          "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         },
         {
           "plain": "End of the page list."
@@ -166,19 +160,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         },
         {
           "plain": "End of the list."
@@ -259,19 +250,16 @@
           "plain": "Start of the page list."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Page 1"
         },
         {
-          "plain": "Page 2",
-          "startsNewBlock": true
+          "plain": "Page 2"
         },
         {
-          "plain": "Page 3",
-          "startsNewBlock": true
+          "plain": "Page 3"
         },
         {
           "plain": "End of the list."
@@ -344,22 +332,19 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 1"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 2"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 3"
@@ -438,106 +423,6 @@
       "utterances": [
         {
           "plain": "Start of the page list."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Page 1"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Page 2"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Page 3"
-        },
-        {
-          "plain": "End of the page list."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -546,15 +431,109 @@
           "plain": "Page 1"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 2"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Page 3"
+        },
+        {
+          "plain": "End of the page list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Page 1"
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Page 2"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Page 3"
@@ -646,8 +625,7 @@
           "plain": "Start of the page list."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -656,15 +634,13 @@
           "plain": "Page 1"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 2"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Page 3"
@@ -685,16 +661,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Page 1",
-          "startsNewBlock": true
+          "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         }
       ]
     },
@@ -764,16 +737,13 @@
           "ssml": "Start of the page list."
         },
         {
-          "ssml": "Page 1",
-          "startsNewBlock": true
+          "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         },
         {
           "ssml": "End of the page list."
@@ -843,19 +813,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         },
         {
           "ssml": "End of the list."
@@ -936,19 +903,16 @@
           "ssml": "Start of the page list."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Page 1"
         },
         {
-          "ssml": "Page 2",
-          "startsNewBlock": true
+          "ssml": "Page 2"
         },
         {
-          "ssml": "Page 3",
-          "startsNewBlock": true
+          "ssml": "Page 3"
         },
         {
           "ssml": "End of the list."
@@ -1021,22 +985,19 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 1"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 2"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 3"
@@ -1115,106 +1076,6 @@
       "utterances": [
         {
           "ssml": "Start of the page list."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Page 1"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Page 2"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Page 3"
-        },
-        {
-          "ssml": "End of the page list."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1223,15 +1084,109 @@
           "ssml": "Page 1"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 2"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Page 3"
+        },
+        {
+          "ssml": "End of the page list."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Page 1"
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Page 2"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Page 3"
@@ -1323,8 +1278,7 @@
           "ssml": "Start of the page list."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -1333,15 +1287,13 @@
           "ssml": "Page 1"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 2"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Page 3"

--- a/fixtures/paragraph-basic/utterances.json
+++ b/fixtures/paragraph-basic/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.",
-          "startsNewBlock": true
+          "plain": "It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife."
         }
       ]
     },
@@ -21,8 +20,7 @@
       ],
       "utterances": [
         {
-          "ssml": "It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.",
-          "startsNewBlock": true
+          "ssml": "It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife."
         }
       ]
     }

--- a/fixtures/part-epub-type/utterances.json
+++ b/fixtures/part-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Title of the part",
-          "startsNewBlock": true
+          "plain": "Title of the part"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the part.",
-          "startsNewBlock": true
+          "plain": "Start of the part."
         },
         {
           "plain": "Title of the part"
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Title of the part"
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the part.",
-          "startsNewBlock": true
+          "plain": "Start of the part."
         },
         {
           "plain": "Heading level 1."
@@ -251,8 +247,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Title of the part",
-          "startsNewBlock": true
+          "ssml": "Title of the part"
         }
       ]
     },
@@ -319,8 +314,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the part.",
-          "startsNewBlock": true
+          "ssml": "Start of the part."
         },
         {
           "ssml": "Title of the part"
@@ -393,8 +387,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Title of the part"
@@ -472,8 +465,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the part.",
-          "startsNewBlock": true
+          "ssml": "Start of the part."
         },
         {
           "ssml": "Heading level 1."

--- a/fixtures/part-role-aria/utterances.json
+++ b/fixtures/part-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Title of the part",
-          "startsNewBlock": true
+          "plain": "Title of the part"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the part.",
-          "startsNewBlock": true
+          "plain": "Start of the part."
         },
         {
           "plain": "Title of the part"
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Heading level 1.",
-          "startsNewBlock": true
+          "plain": "Heading level 1."
         },
         {
           "plain": "Title of the part"
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the part.",
-          "startsNewBlock": true
+          "plain": "Start of the part."
         },
         {
           "plain": "Heading level 1."
@@ -251,8 +247,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Title of the part",
-          "startsNewBlock": true
+          "ssml": "Title of the part"
         }
       ]
     },
@@ -319,8 +314,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the part.",
-          "startsNewBlock": true
+          "ssml": "Start of the part."
         },
         {
           "ssml": "Title of the part"
@@ -393,8 +387,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Heading level 1.",
-          "startsNewBlock": true
+          "ssml": "Heading level 1."
         },
         {
           "ssml": "Title of the part"
@@ -472,8 +465,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the part.",
-          "startsNewBlock": true
+          "ssml": "Start of the part."
         },
         {
           "ssml": "Heading level 1."

--- a/fixtures/preface-epub-type/utterances.json
+++ b/fixtures/preface-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "This edition adds a chapter on automation.",
-          "startsNewBlock": true
+          "plain": "This edition adds a chapter on automation."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the preface.",
-          "startsNewBlock": true
+          "plain": "Start of the preface."
         },
         {
           "plain": "This edition adds a chapter on automation."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This edition adds a chapter on automation.",
-          "startsNewBlock": true
+          "ssml": "This edition adds a chapter on automation."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the preface.",
-          "startsNewBlock": true
+          "ssml": "Start of the preface."
         },
         {
           "ssml": "This edition adds a chapter on automation."

--- a/fixtures/preface-role-aria/utterances.json
+++ b/fixtures/preface-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "This edition adds a chapter on automation.",
-          "startsNewBlock": true
+          "plain": "This edition adds a chapter on automation."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the preface.",
-          "startsNewBlock": true
+          "plain": "Start of the preface."
         },
         {
           "plain": "This edition adds a chapter on automation."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "This edition adds a chapter on automation.",
-          "startsNewBlock": true
+          "ssml": "This edition adds a chapter on automation."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the preface.",
-          "startsNewBlock": true
+          "ssml": "Start of the preface."
         },
         {
           "ssml": "This edition adds a chapter on automation."

--- a/fixtures/preformatted-html-native/utterances.json
+++ b/fixtures/preformatted-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "10 PRINT \"HELLO\" 20 GOTO 10",
-          "startsNewBlock": true
+          "plain": "10 PRINT \"HELLO\" 20 GOTO 10"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the preformatted text.",
-          "startsNewBlock": true
+          "plain": "Start of the preformatted text."
         },
         {
           "plain": "10 PRINT \"HELLO\" 20 GOTO 10"
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "10 PRINT \"HELLO\" 20 GOTO 10",
-          "startsNewBlock": true
+          "ssml": "10 PRINT \"HELLO\" 20 GOTO 10"
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the preformatted text.",
-          "startsNewBlock": true
+          "ssml": "Start of the preformatted text."
         },
         {
           "ssml": "10 PRINT \"HELLO\" 20 GOTO 10"

--- a/fixtures/prologue-epub-type/utterances.json
+++ b/fixtures/prologue-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Before the lamp was ever lit, the rock was already feared.",
-          "startsNewBlock": true
+          "plain": "Before the lamp was ever lit, the rock was already feared."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the prologue.",
-          "startsNewBlock": true
+          "plain": "Start of the prologue."
         },
         {
           "plain": "Before the lamp was ever lit, the rock was already feared."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Before the lamp was ever lit, the rock was already feared.",
-          "startsNewBlock": true
+          "ssml": "Before the lamp was ever lit, the rock was already feared."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the prologue.",
-          "startsNewBlock": true
+          "ssml": "Start of the prologue."
         },
         {
           "ssml": "Before the lamp was ever lit, the rock was already feared."

--- a/fixtures/prologue-role-aria/utterances.json
+++ b/fixtures/prologue-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Before the lamp was ever lit, the rock was already feared.",
-          "startsNewBlock": true
+          "plain": "Before the lamp was ever lit, the rock was already feared."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the prologue.",
-          "startsNewBlock": true
+          "plain": "Start of the prologue."
         },
         {
           "plain": "Before the lamp was ever lit, the rock was already feared."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Before the lamp was ever lit, the rock was already feared.",
-          "startsNewBlock": true
+          "ssml": "Before the lamp was ever lit, the rock was already feared."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the prologue.",
-          "startsNewBlock": true
+          "ssml": "Start of the prologue."
         },
         {
           "ssml": "Before the lamp was ever lit, the rock was already feared."

--- a/fixtures/pullquote-epub-type/utterances.json
+++ b/fixtures/pullquote-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "plain": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the aside.",
-          "startsNewBlock": true
+          "plain": "Start of the aside."
         },
         {
           "plain": "The lamp still turns, though no one climbs the stairs anymore."
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Pull quote.",
-          "startsNewBlock": true
+          "plain": "Pull quote."
         },
         {
           "plain": "The lamp still turns, though no one climbs the stairs anymore."
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the aside.",
-          "startsNewBlock": true
+          "plain": "Start of the aside."
         },
         {
           "plain": "Pull quote."
@@ -1224,8 +1220,7 @@
       ],
       "utterances": [
         {
-          "ssml": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "ssml": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -1292,8 +1287,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the aside.",
-          "startsNewBlock": true
+          "ssml": "Start of the aside."
         },
         {
           "ssml": "The lamp still turns, though no one climbs the stairs anymore."
@@ -1366,8 +1360,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Pull quote.",
-          "startsNewBlock": true
+          "ssml": "Pull quote."
         },
         {
           "ssml": "The lamp still turns, though no one climbs the stairs anymore."
@@ -1445,8 +1438,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the aside.",
-          "startsNewBlock": true
+          "ssml": "Start of the aside."
         },
         {
           "ssml": "Pull quote."

--- a/fixtures/pullquote-role-aria/utterances.json
+++ b/fixtures/pullquote-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "plain": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Pull quote.",
-          "startsNewBlock": true
+          "plain": "Pull quote."
         },
         {
           "plain": "The lamp still turns, though no one climbs the stairs anymore."
@@ -237,8 +235,7 @@
       ],
       "utterances": [
         {
-          "ssml": "The lamp still turns, though no one climbs the stairs anymore.",
-          "startsNewBlock": true
+          "ssml": "The lamp still turns, though no one climbs the stairs anymore."
         }
       ]
     },
@@ -305,8 +302,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Pull quote.",
-          "startsNewBlock": true
+          "ssml": "Pull quote."
         },
         {
           "ssml": "The lamp still turns, though no one climbs the stairs anymore."

--- a/fixtures/qna-epub-type/utterances.json
+++ b/fixtures/qna-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Q: How often was the lamp refueled? A: Nightly, by hand.",
-          "startsNewBlock": true
+          "plain": "Q: How often was the lamp refueled? A: Nightly, by hand."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the questions and answers.",
-          "startsNewBlock": true
+          "plain": "Start of the questions and answers."
         },
         {
           "plain": "Q: How often was the lamp refueled? A: Nightly, by hand."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Q: How often was the lamp refueled? A: Nightly, by hand.",
-          "startsNewBlock": true
+          "ssml": "Q: How often was the lamp refueled? A: Nightly, by hand."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the questions and answers.",
-          "startsNewBlock": true
+          "ssml": "Start of the questions and answers."
         },
         {
           "ssml": "Q: How often was the lamp refueled? A: Nightly, by hand."

--- a/fixtures/qna-role-aria/utterances.json
+++ b/fixtures/qna-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Q: How often was the lamp refueled? A: Nightly, by hand.",
-          "startsNewBlock": true
+          "plain": "Q: How often was the lamp refueled? A: Nightly, by hand."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the questions and answers.",
-          "startsNewBlock": true
+          "plain": "Start of the questions and answers."
         },
         {
           "plain": "Q: How often was the lamp refueled? A: Nightly, by hand."
@@ -95,8 +93,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Q: How often was the lamp refueled? A: Nightly, by hand.",
-          "startsNewBlock": true
+          "ssml": "Q: How often was the lamp refueled? A: Nightly, by hand."
         }
       ]
     },
@@ -163,8 +160,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the questions and answers.",
-          "startsNewBlock": true
+          "ssml": "Start of the questions and answers."
         },
         {
           "ssml": "Q: How often was the lamp refueled? A: Nightly, by hand."

--- a/fixtures/section-html-native/utterances.json
+++ b/fixtures/section-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "The lighthouse was decommissioned in 1998, though its light still functions as a private aid to navigation.",
-          "startsNewBlock": true
+          "plain": "The lighthouse was decommissioned in 1998, though its light still functions as a private aid to navigation."
         }
       ]
     },
@@ -21,8 +20,7 @@
       ],
       "utterances": [
         {
-          "ssml": "The lighthouse was decommissioned in 1998, though its light still functions as a private aid to navigation.",
-          "startsNewBlock": true
+          "ssml": "The lighthouse was decommissioned in 1998, though its light still functions as a private aid to navigation."
         }
       ]
     }

--- a/fixtures/separator-html-native/utterances.json
+++ b/fixtures/separator-html-native/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Section one.",
-          "startsNewBlock": true
+          "plain": "Section one."
         },
         {
-          "plain": "Section two.",
-          "startsNewBlock": true
+          "plain": "Section two."
         }
       ]
     },
@@ -25,12 +23,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Section one.",
-          "startsNewBlock": true
+          "ssml": "Section one."
         },
         {
-          "ssml": "Section two.",
-          "startsNewBlock": true
+          "ssml": "Section two."
         }
       ]
     }

--- a/fixtures/separator-role-aria/utterances.json
+++ b/fixtures/separator-role-aria/utterances.json
@@ -8,12 +8,10 @@
       ],
       "utterances": [
         {
-          "plain": "Section one.",
-          "startsNewBlock": true
+          "plain": "Section one."
         },
         {
-          "plain": "Section two.",
-          "startsNewBlock": true
+          "plain": "Section two."
         }
       ]
     },
@@ -25,12 +23,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Section one.",
-          "startsNewBlock": true
+          "ssml": "Section one."
         },
         {
-          "ssml": "Section two.",
-          "startsNewBlock": true
+          "ssml": "Section two."
         }
       ]
     }

--- a/fixtures/summary-html-native/utterances.json
+++ b/fixtures/summary-html-native/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Click to expand",
-          "startsNewBlock": true
+          "plain": "Click to expand"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Summary.",
-          "startsNewBlock": true
+          "plain": "Summary."
         },
         {
           "plain": "Click to expand"
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Click to expand",
-          "startsNewBlock": true
+          "ssml": "Click to expand"
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Summary.",
-          "startsNewBlock": true
+          "ssml": "Summary."
         },
         {
           "ssml": "Click to expand"

--- a/fixtures/table-html-native/utterances.json
+++ b/fixtures/table-html-native/utterances.json
@@ -8,28 +8,22 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -96,31 +90,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -190,43 +178,37 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -304,8 +286,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -314,36 +295,31 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -416,34 +392,28 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -518,8 +488,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -528,27 +497,22 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -626,8 +590,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -636,8 +599,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -646,29 +608,25 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -754,8 +712,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -767,8 +724,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -777,29 +733,25 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -872,34 +824,28 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -974,37 +920,31 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -1082,22 +1022,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1106,15 +1043,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1123,8 +1058,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1210,8 +1144,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -1220,15 +1153,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1237,15 +1168,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1254,8 +1183,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1336,40 +1264,34 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -1452,8 +1374,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -1462,33 +1383,28 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -1574,8 +1490,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -1584,8 +1499,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -1594,8 +1508,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1604,15 +1517,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1621,8 +1532,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1716,8 +1626,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -1729,8 +1638,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -1739,8 +1647,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1749,15 +1656,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1766,8 +1671,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1840,31 +1744,25 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -1942,34 +1840,28 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2050,29 +1942,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2081,15 +1969,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2178,8 +2064,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -2188,22 +2073,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2212,15 +2094,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2304,37 +2184,31 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2420,8 +2294,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -2430,30 +2303,25 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2542,8 +2410,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -2552,8 +2419,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -2562,15 +2428,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2579,15 +2443,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2684,8 +2546,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -2697,8 +2558,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -2707,15 +2567,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2724,15 +2582,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2816,37 +2672,31 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2932,40 +2782,34 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3054,22 +2898,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3078,8 +2919,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3088,8 +2928,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3098,8 +2937,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3196,8 +3034,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -3206,15 +3043,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3223,8 +3058,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3233,8 +3067,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3243,8 +3076,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3336,43 +3168,37 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3466,8 +3292,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -3476,36 +3301,31 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3602,8 +3422,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -3612,8 +3431,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -3622,8 +3440,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3632,8 +3449,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3642,8 +3458,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3652,8 +3467,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3758,8 +3572,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -3771,8 +3584,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -3781,8 +3593,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3791,8 +3602,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3801,8 +3611,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3811,8 +3620,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3970,20 +3778,16 @@
       ],
       "utterances": [
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -4164,24 +3968,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -4365,36 +4164,31 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -4594,8 +4388,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -4604,29 +4397,25 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -4813,26 +4602,22 @@
       ],
       "utterances": [
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -5029,30 +4814,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -5252,15 +5032,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5269,15 +5047,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5286,8 +5062,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -5503,8 +5278,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -5513,8 +5287,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5523,15 +5296,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5540,8 +5311,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -5728,23 +5498,19 @@
       ],
       "utterances": [
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -5944,27 +5710,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6167,22 +5928,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -6191,15 +5949,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6418,8 +6174,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -6428,15 +6183,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -6445,15 +6198,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6659,29 +6410,25 @@
       ],
       "utterances": [
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6897,33 +6644,28 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -7142,15 +6884,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7159,8 +6899,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -7169,8 +6908,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7179,8 +6917,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -7415,8 +7152,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -7425,8 +7161,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7435,8 +7170,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -7445,8 +7179,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7455,8 +7188,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -7613,871 +7345,847 @@
         }
       ],
       "utterances": [
-        {
-          "plain": "Name",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
-        },
         {
           "plain": "Name"
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Name"
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Start of the row."
-        },
-        {
-          "plain": "Name"
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Column header.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Name"
-        },
-        {
-          "plain": "Column header.",
-          "startsNewBlock": true
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the table."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "Admiral"
+        },
+        {
+          "plain": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Admiral"
+        },
+        {
+          "plain": "End of the row."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the table."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Admiral"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Column header."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Column header."
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "Admiral"
         }
       ]
     },
@@ -8674,8 +8382,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -8684,19 +8391,16 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -8896,8 +8600,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -8906,8 +8609,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -8916,23 +8618,19 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -9148,8 +8846,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -9161,8 +8858,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -9171,23 +8867,19 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -9374,23 +9066,19 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -9590,26 +9278,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -9812,26 +9496,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -9840,12 +9520,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10064,8 +9742,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -10074,19 +9751,16 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -10095,12 +9769,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10306,29 +9978,25 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10544,8 +10212,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -10554,22 +10221,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10788,8 +10452,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -10798,8 +10461,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -10808,12 +10470,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -10822,12 +10482,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -11062,8 +10720,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -11075,8 +10732,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -11085,12 +10741,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -11099,12 +10753,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -11466,12 +11118,10 @@
       ],
       "utterances": [
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -11872,16 +11522,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -12285,30 +11932,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -12744,8 +12386,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -12754,23 +12395,19 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -13177,15 +12814,13 @@
       ],
       "utterances": [
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -13621,19 +13256,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -14072,19 +13704,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -14093,12 +13722,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -14569,8 +14196,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -14579,12 +14205,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -14593,12 +14217,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -99373,8 +98995,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "End of the table."
@@ -99526,20 +99147,16 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         }
       ]
     },
@@ -99720,23 +99337,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
           "plain": "End of the table."
@@ -99920,22 +99533,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -99944,8 +99554,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -100148,8 +99757,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -100158,15 +99766,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -100175,8 +99781,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -100366,26 +99971,22 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         }
       ]
     },
@@ -100582,8 +100183,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -100592,19 +100192,16 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
           "plain": "End of the table."
@@ -100804,8 +100401,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -100814,8 +100410,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -100824,8 +100419,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -100834,8 +100428,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -101054,8 +100647,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -101067,8 +100659,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -101077,8 +100668,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -101087,8 +100677,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -101278,23 +100867,19 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -101494,26 +101079,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -101716,22 +101297,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -101743,8 +101321,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -101966,8 +101543,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -101976,15 +101552,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -101996,8 +101570,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102206,29 +101779,25 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -102444,8 +102013,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -102454,22 +102022,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -102688,8 +102253,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -102698,8 +102262,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -102708,8 +102271,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102721,8 +102283,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102960,8 +102521,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -102973,8 +102533,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -102983,8 +102542,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102996,8 +102554,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -103362,12 +102919,10 @@
       ],
       "utterances": [
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         }
       ]
     },
@@ -103768,16 +103323,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
           "plain": "End of the table."
@@ -104181,15 +103733,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -104198,8 +103748,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -104638,8 +104187,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -104648,8 +104196,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -104658,8 +104205,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -105069,15 +104615,13 @@
       ],
       "utterances": [
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -105513,19 +105057,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -105964,15 +105505,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -105984,8 +105523,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -106459,8 +105997,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -106469,8 +106006,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -106482,8 +106018,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -106848,12 +106383,10 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         }
       ]
     },
@@ -107254,15 +106787,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the table."
@@ -107666,29 +107197,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -108124,8 +107651,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -108134,22 +107660,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -108556,15 +108079,13 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109000,8 +108521,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -109010,8 +108530,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109450,8 +108969,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -109460,8 +108978,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109470,15 +108987,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -109946,8 +109461,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -109959,8 +109473,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109969,15 +109482,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -110872,22 +110383,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -111843,8 +111351,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -111853,15 +111360,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -111879,28 +111384,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -111967,31 +111466,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -112061,43 +111554,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112175,8 +111662,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -112185,36 +111671,31 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112287,34 +111768,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -112389,8 +111864,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -112399,27 +111873,22 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -112497,8 +111966,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -112507,8 +111975,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -112517,29 +111984,25 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112625,8 +112088,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -112638,8 +112100,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -112648,29 +112109,25 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112743,34 +112200,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -112845,37 +112296,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -112953,22 +112398,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -112977,15 +112419,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -112994,8 +112434,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113081,8 +112520,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -113091,15 +112529,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113108,15 +112544,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113125,8 +112559,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113207,40 +112640,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -113323,8 +112750,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -113333,33 +112759,28 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -113445,8 +112866,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -113455,8 +112875,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -113465,8 +112884,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113475,15 +112893,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113492,8 +112908,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113587,8 +113002,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -113600,8 +113014,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -113610,8 +113023,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113620,15 +113032,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113637,8 +113047,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113711,31 +113120,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -113813,34 +113216,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -113921,29 +113318,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -113952,15 +113345,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114049,8 +113440,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -114059,22 +113449,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114083,15 +113470,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114175,37 +113560,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114291,8 +113670,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -114301,30 +113679,25 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114413,8 +113786,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -114423,8 +113795,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -114433,15 +113804,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114450,15 +113819,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114555,8 +113922,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -114568,8 +113934,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -114578,15 +113943,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114595,15 +113958,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114687,37 +114048,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114803,40 +114158,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114925,22 +114274,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -114949,8 +114295,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114959,8 +114304,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -114969,8 +114313,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115067,8 +114410,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -115077,15 +114419,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115094,8 +114434,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -115104,8 +114443,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115114,8 +114452,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115207,43 +114544,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115337,8 +114668,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -115347,36 +114677,31 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115473,8 +114798,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -115483,8 +114807,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -115493,8 +114816,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115503,8 +114825,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -115513,8 +114834,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115523,8 +114843,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115629,8 +114948,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -115642,8 +114960,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -115652,8 +114969,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115662,8 +114978,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -115672,8 +114987,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115682,8 +114996,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115841,20 +115154,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -116035,24 +115344,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -116236,36 +115540,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -116465,8 +115764,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -116475,29 +115773,25 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -116684,26 +115978,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -116900,30 +116190,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -117123,15 +116408,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117140,15 +116423,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117157,8 +116438,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -117374,8 +116654,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -117384,8 +116663,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117394,15 +116672,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117411,8 +116687,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -117599,23 +116874,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -117815,27 +117086,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118038,22 +117304,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -118062,15 +117325,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118289,8 +117550,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -118299,15 +117559,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -118316,15 +117574,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118530,29 +117786,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118768,33 +118020,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -119013,15 +118260,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119030,8 +118275,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -119040,8 +118284,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119050,8 +118293,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -119286,8 +118528,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -119296,8 +118537,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119306,8 +118546,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -119316,8 +118555,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119326,8 +118564,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -119484,871 +118721,847 @@
         }
       ],
       "utterances": [
-        {
-          "ssml": "Name",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
-        },
         {
           "ssml": "Name"
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Name"
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Start of the row."
-        },
-        {
-          "ssml": "Name"
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Column header.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Name"
-        },
-        {
-          "ssml": "Column header.",
-          "startsNewBlock": true
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the table."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "Admiral"
+        },
+        {
+          "ssml": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Admiral"
+        },
+        {
+          "ssml": "End of the row."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the table."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Admiral"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Column header."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Column header."
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "Admiral"
         }
       ]
     },
@@ -120545,8 +119758,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -120555,19 +119767,16 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -120767,8 +119976,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -120777,8 +119985,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -120787,23 +119994,19 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -121019,8 +120222,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -121032,8 +120234,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -121042,23 +120243,19 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -121245,23 +120442,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -121461,26 +120654,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -121683,26 +120872,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -121711,12 +120896,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -121935,8 +121118,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -121945,19 +121127,16 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -121966,12 +121145,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122177,29 +121354,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122415,8 +121588,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -122425,22 +121597,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122659,8 +121828,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -122669,8 +121837,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -122679,12 +121846,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -122693,12 +121858,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122933,8 +122096,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -122946,8 +122108,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -122956,12 +122117,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -122970,12 +122129,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -123337,12 +122494,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -123743,16 +122898,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -124156,30 +123308,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -124615,8 +123762,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -124625,23 +123771,19 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -125048,15 +124190,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -125492,19 +124632,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -125943,19 +125080,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -125964,12 +125098,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -126440,8 +125572,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -126450,12 +125581,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -126464,12 +125593,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -211244,8 +210371,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "End of the table."
@@ -211397,20 +210523,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         }
       ]
     },
@@ -211591,23 +210713,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
           "ssml": "End of the table."
@@ -211791,22 +210909,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -211815,8 +210930,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -212019,8 +211133,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -212029,15 +211142,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -212046,8 +211157,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -212237,26 +211347,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         }
       ]
     },
@@ -212453,8 +211559,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -212463,19 +211568,16 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
           "ssml": "End of the table."
@@ -212675,8 +211777,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -212685,8 +211786,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -212695,8 +211795,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -212705,8 +211804,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -212925,8 +212023,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -212938,8 +212035,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -212948,8 +212044,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -212958,8 +212053,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -213149,23 +212243,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -213365,26 +212455,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -213587,22 +212673,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -213614,8 +212697,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -213837,8 +212919,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -213847,15 +212928,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -213867,8 +212946,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214077,29 +213155,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -214315,8 +213389,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -214325,22 +213398,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -214559,8 +213629,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -214569,8 +213638,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -214579,8 +213647,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214592,8 +213659,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214831,8 +213897,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -214844,8 +213909,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -214854,8 +213918,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214867,8 +213930,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -215233,12 +214295,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         }
       ]
     },
@@ -215639,16 +214699,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
           "ssml": "End of the table."
@@ -216052,15 +215109,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -216069,8 +215124,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -216509,8 +215563,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -216519,8 +215572,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -216529,8 +215581,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -216940,15 +215991,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -217384,19 +216433,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -217835,15 +216881,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -217855,8 +216899,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -218330,8 +217373,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -218340,8 +217382,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -218353,8 +217394,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -218719,12 +217759,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         }
       ]
     },
@@ -219125,15 +218163,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the table."
@@ -219537,29 +218573,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -219995,8 +219027,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -220005,22 +219036,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -220427,15 +219455,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -220871,8 +219897,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -220881,8 +219906,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -221321,8 +220345,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -221331,8 +220354,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -221341,15 +220363,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -221817,8 +220837,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -221830,8 +220849,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -221840,15 +220858,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -222743,22 +221759,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -223714,8 +222727,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -223724,15 +222736,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."

--- a/fixtures/table-role-aria/utterances.json
+++ b/fixtures/table-role-aria/utterances.json
@@ -8,28 +8,22 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -96,31 +90,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -190,43 +178,37 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -304,8 +286,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -314,36 +295,31 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -416,34 +392,28 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -518,8 +488,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -528,27 +497,22 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -626,8 +590,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -636,8 +599,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -646,29 +608,25 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -754,8 +712,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -767,8 +724,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -777,29 +733,25 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -872,34 +824,28 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -974,37 +920,31 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -1082,22 +1022,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1106,15 +1043,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1123,8 +1058,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1210,8 +1144,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -1220,15 +1153,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1237,15 +1168,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1254,8 +1183,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1336,40 +1264,34 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -1452,8 +1374,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -1462,33 +1383,28 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -1574,8 +1490,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -1584,8 +1499,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -1594,8 +1508,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1604,15 +1517,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1621,8 +1532,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1716,8 +1626,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -1729,8 +1638,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -1739,8 +1647,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1749,15 +1656,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -1766,8 +1671,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -1840,31 +1744,25 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -1942,34 +1840,28 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2050,29 +1942,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2081,15 +1969,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2178,8 +2064,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -2188,22 +2073,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2212,15 +2094,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2304,37 +2184,31 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2420,8 +2294,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -2430,30 +2303,25 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2542,8 +2410,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -2552,8 +2419,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -2562,15 +2428,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2579,15 +2443,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2684,8 +2546,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -2697,8 +2558,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -2707,15 +2567,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -2724,15 +2582,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2816,37 +2672,31 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -2932,40 +2782,34 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3054,22 +2898,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3078,8 +2919,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3088,8 +2928,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3098,8 +2937,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3196,8 +3034,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -3206,15 +3043,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3223,8 +3058,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3233,8 +3067,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3243,8 +3076,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3336,43 +3168,37 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3466,8 +3292,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -3476,36 +3301,31 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3602,8 +3422,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -3612,8 +3431,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -3622,8 +3440,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3632,8 +3449,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3642,8 +3458,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3652,8 +3467,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3758,8 +3572,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -3771,8 +3584,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -3781,8 +3593,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3791,8 +3602,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -3801,8 +3611,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -3811,8 +3620,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -3970,20 +3778,16 @@
       ],
       "utterances": [
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -4164,24 +3968,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -4365,36 +4164,31 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -4594,8 +4388,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -4604,29 +4397,25 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -4813,26 +4602,22 @@
       ],
       "utterances": [
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -5029,30 +4814,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -5252,15 +5032,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5269,15 +5047,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5286,8 +5062,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -5503,8 +5278,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -5513,8 +5287,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5523,15 +5296,13 @@
           "plain": "Ada"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -5540,8 +5311,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -5728,23 +5498,19 @@
       ],
       "utterances": [
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -5944,27 +5710,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6167,22 +5928,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -6191,15 +5949,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6418,8 +6174,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -6428,15 +6183,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -6445,15 +6198,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6659,29 +6410,25 @@
       ],
       "utterances": [
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -6897,33 +6644,28 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -7142,15 +6884,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7159,8 +6899,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -7169,8 +6908,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7179,8 +6917,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -7415,8 +7152,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -7425,8 +7161,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7435,8 +7170,7 @@
           "plain": "Ada"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -7445,8 +7179,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -7455,8 +7188,7 @@
           "plain": "Grace"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -7613,871 +7345,847 @@
         }
       ],
       "utterances": [
-        {
-          "plain": "Name",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
-        },
         {
           "plain": "Name"
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Name"
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Start of the row."
-        },
-        {
-          "plain": "Name"
-        },
-        {
-          "plain": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "End of the row."
-        },
-        {
-          "plain": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Column header.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Name"
-        },
-        {
-          "plain": "Column header.",
-          "startsNewBlock": true
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the table."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "Admiral"
+        },
+        {
+          "plain": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Admiral"
+        },
+        {
+          "plain": "End of the row."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the table."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "Start of the row."
+        },
+        {
+          "plain": "Admiral"
+        },
+        {
+          "plain": "End of the row."
+        },
+        {
+          "plain": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Column header."
+        },
+        {
+          "plain": "Name"
+        },
+        {
+          "plain": "Column header."
+        },
+        {
+          "plain": "Role"
+        },
+        {
+          "plain": "Engineer"
+        },
+        {
+          "plain": "Admiral"
         }
       ]
     },
@@ -8674,8 +8382,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -8684,19 +8391,16 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -8896,8 +8600,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -8906,8 +8609,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -8916,23 +8618,19 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -9148,8 +8846,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -9161,8 +8858,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -9171,23 +8867,19 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -9374,23 +9066,19 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -9590,26 +9278,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -9812,26 +9496,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -9840,12 +9520,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10064,8 +9742,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -10074,19 +9751,16 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -10095,12 +9769,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10306,29 +9978,25 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10544,8 +10212,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -10554,22 +10221,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -10788,8 +10452,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -10798,8 +10461,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -10808,12 +10470,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -10822,12 +10482,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -11062,8 +10720,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -11075,8 +10732,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -11085,12 +10741,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -11099,12 +10753,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -11466,12 +11118,10 @@
       ],
       "utterances": [
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         }
       ]
     },
@@ -11872,16 +11522,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the table."
@@ -12285,30 +11932,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -12744,8 +12386,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -12754,23 +12395,19 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Engineer",
-          "startsNewBlock": true
+          "plain": "Engineer"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Admiral",
-          "startsNewBlock": true
+          "plain": "Admiral"
         },
         {
           "plain": "End of the row."
@@ -13177,15 +12814,13 @@
       ],
       "utterances": [
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -13621,19 +13256,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -14072,19 +13704,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -14093,12 +13722,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -14569,8 +14196,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -14579,12 +14205,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Engineer"
@@ -14593,12 +14217,10 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
-          "plain": "Cell.",
-          "startsNewBlock": true
+          "plain": "Cell."
         },
         {
           "plain": "Admiral"
@@ -99373,8 +98995,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "End of the table."
@@ -99526,20 +99147,16 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         }
       ]
     },
@@ -99720,23 +99337,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
           "plain": "End of the table."
@@ -99920,22 +99533,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -99944,8 +99554,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -100148,8 +99757,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -100158,15 +99766,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -100175,8 +99781,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -100366,26 +99971,22 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         }
       ]
     },
@@ -100582,8 +100183,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -100592,19 +100192,16 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
           "plain": "End of the table."
@@ -100804,8 +100401,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -100814,8 +100410,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -100824,8 +100419,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -100834,8 +100428,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -101054,8 +100647,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -101067,8 +100659,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -101077,8 +100668,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -101087,8 +100677,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -101278,23 +100867,19 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -101494,26 +101079,22 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -101716,22 +101297,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -101743,8 +101321,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -101966,8 +101543,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -101976,15 +101552,13 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -101996,8 +101570,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102206,29 +101779,25 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -102444,8 +102013,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -102454,22 +102022,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -102688,8 +102253,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -102698,8 +102262,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -102708,8 +102271,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102721,8 +102283,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102960,8 +102521,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -102973,8 +102533,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -102983,8 +102542,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -102996,8 +102554,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -103362,12 +102919,10 @@
       ],
       "utterances": [
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         }
       ]
     },
@@ -103768,16 +103323,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Ada",
-          "startsNewBlock": true
+          "plain": "Ada"
         },
         {
-          "plain": "Grace",
-          "startsNewBlock": true
+          "plain": "Grace"
         },
         {
           "plain": "End of the table."
@@ -104181,15 +103733,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -104198,8 +103748,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -104638,8 +104187,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -104648,8 +104196,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Ada"
@@ -104658,8 +104205,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Grace"
@@ -105069,15 +104615,13 @@
       ],
       "utterances": [
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -105513,19 +105057,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Ada"
         },
         {
-          "plain": "Row header.",
-          "startsNewBlock": true
+          "plain": "Row header."
         },
         {
           "plain": "Grace"
@@ -105964,15 +105505,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -105984,8 +105523,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -106459,8 +105997,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -106469,8 +106006,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -106482,8 +106018,7 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Row header."
@@ -106848,12 +106383,10 @@
       ],
       "utterances": [
         {
-          "plain": "Name",
-          "startsNewBlock": true
+          "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         }
       ]
     },
@@ -107254,15 +106787,13 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the table."
@@ -107666,29 +107197,25 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -108124,8 +107651,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -108134,22 +107660,19 @@
           "plain": "Name"
         },
         {
-          "plain": "Role",
-          "startsNewBlock": true
+          "plain": "Role"
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -108556,15 +108079,13 @@
       ],
       "utterances": [
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109000,8 +108521,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Column header."
@@ -109010,8 +108530,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109450,8 +108969,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "Column header."
@@ -109460,8 +108978,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109470,15 +108987,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -109946,8 +109461,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -109959,8 +109473,7 @@
           "plain": "Name"
         },
         {
-          "plain": "Column header.",
-          "startsNewBlock": true
+          "plain": "Column header."
         },
         {
           "plain": "Role"
@@ -109969,15 +109482,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -110872,22 +110383,19 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -111843,8 +111351,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the table.",
-          "startsNewBlock": true
+          "plain": "Start of the table."
         },
         {
           "plain": "Start of the row."
@@ -111853,15 +111360,13 @@
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
         },
         {
-          "plain": "Start of the row.",
-          "startsNewBlock": true
+          "plain": "Start of the row."
         },
         {
           "plain": "End of the row."
@@ -111879,28 +111384,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -111967,31 +111466,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -112061,43 +111554,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112175,8 +111662,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -112185,36 +111671,31 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112287,34 +111768,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -112389,8 +111864,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -112399,27 +111873,22 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -112497,8 +111966,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -112507,8 +111975,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -112517,29 +111984,25 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112625,8 +112088,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -112638,8 +112100,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -112648,29 +112109,25 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -112743,34 +112200,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -112845,37 +112296,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -112953,22 +112398,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -112977,15 +112419,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -112994,8 +112434,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113081,8 +112520,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -113091,15 +112529,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113108,15 +112544,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113125,8 +112559,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113207,40 +112640,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -113323,8 +112750,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -113333,33 +112759,28 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -113445,8 +112866,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -113455,8 +112875,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -113465,8 +112884,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113475,15 +112893,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113492,8 +112908,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113587,8 +113002,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -113600,8 +113014,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -113610,8 +113023,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113620,15 +113032,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -113637,8 +113047,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -113711,31 +113120,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -113813,34 +113216,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -113921,29 +113318,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -113952,15 +113345,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114049,8 +113440,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -114059,22 +113449,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114083,15 +113470,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114175,37 +113560,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114291,8 +113670,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -114301,30 +113679,25 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114413,8 +113786,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -114423,8 +113795,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -114433,15 +113804,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114450,15 +113819,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114555,8 +113922,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -114568,8 +113934,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -114578,15 +113943,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114595,15 +113958,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114687,37 +114048,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114803,40 +114158,34 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -114925,22 +114274,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -114949,8 +114295,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -114959,8 +114304,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -114969,8 +114313,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115067,8 +114410,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -115077,15 +114419,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115094,8 +114434,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -115104,8 +114443,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115114,8 +114452,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115207,43 +114544,37 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115337,8 +114668,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -115347,36 +114677,31 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115473,8 +114798,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -115483,8 +114807,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -115493,8 +114816,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115503,8 +114825,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -115513,8 +114834,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115523,8 +114843,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115629,8 +114948,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -115642,8 +114960,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -115652,8 +114969,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115662,8 +114978,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -115672,8 +114987,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -115682,8 +114996,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -115841,20 +115154,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -116035,24 +115344,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -116236,36 +115540,31 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -116465,8 +115764,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -116475,29 +115773,25 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -116684,26 +115978,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -116900,30 +116190,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -117123,15 +116408,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117140,15 +116423,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117157,8 +116438,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -117374,8 +116654,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -117384,8 +116663,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117394,15 +116672,13 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -117411,8 +116687,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -117599,23 +116874,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -117815,27 +117086,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118038,22 +117304,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -118062,15 +117325,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118289,8 +117550,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -118299,15 +117559,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -118316,15 +117574,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118530,29 +117786,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -118768,33 +118020,28 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -119013,15 +118260,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119030,8 +118275,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -119040,8 +118284,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119050,8 +118293,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -119286,8 +118528,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -119296,8 +118537,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119306,8 +118546,7 @@
           "ssml": "Ada"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -119316,8 +118555,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -119326,8 +118564,7 @@
           "ssml": "Grace"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -119484,871 +118721,847 @@
         }
       ],
       "utterances": [
-        {
-          "ssml": "Name",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
-        },
         {
           "ssml": "Name"
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Name"
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "table",
-            "row",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Start of the row."
-        },
-        {
-          "ssml": "Name"
-        },
-        {
-          "ssml": "Role",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Engineer",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Admiral",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "End of the row."
-        },
-        {
-          "ssml": "End of the table."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ]
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "skip": [
-            "rowheader"
-          ],
-          "contextualize": [
-            "columnheader",
-            "rowheader"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Column header.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Name"
-        },
-        {
-          "ssml": "Column header.",
-          "startsNewBlock": true
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the table."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "Admiral"
+        },
+        {
+          "ssml": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Admiral"
+        },
+        {
+          "ssml": "End of the row."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "table",
+            "row",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the table."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "Start of the row."
+        },
+        {
+          "ssml": "Admiral"
+        },
+        {
+          "ssml": "End of the row."
+        },
+        {
+          "ssml": "End of the table."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ]
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "skip": [
+            "rowheader"
+          ],
+          "contextualize": [
+            "columnheader",
+            "rowheader"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Column header."
+        },
+        {
+          "ssml": "Name"
+        },
+        {
+          "ssml": "Column header."
+        },
+        {
+          "ssml": "Role"
+        },
+        {
+          "ssml": "Engineer"
+        },
+        {
+          "ssml": "Admiral"
         }
       ]
     },
@@ -120545,8 +119758,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -120555,19 +119767,16 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -120767,8 +119976,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -120777,8 +119985,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -120787,23 +119994,19 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -121019,8 +120222,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -121032,8 +120234,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -121042,23 +120243,19 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -121245,23 +120442,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -121461,26 +120654,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -121683,26 +120872,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -121711,12 +120896,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -121935,8 +121118,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -121945,19 +121127,16 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -121966,12 +121145,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122177,29 +121354,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122415,8 +121588,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -122425,22 +121597,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122659,8 +121828,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -122669,8 +121837,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -122679,12 +121846,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -122693,12 +121858,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -122933,8 +122096,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -122946,8 +122108,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -122956,12 +122117,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -122970,12 +122129,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -123337,12 +122494,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         }
       ]
     },
@@ -123743,16 +122898,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the table."
@@ -124156,30 +123308,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -124615,8 +123762,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -124625,23 +123771,19 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Engineer",
-          "startsNewBlock": true
+          "ssml": "Engineer"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Admiral",
-          "startsNewBlock": true
+          "ssml": "Admiral"
         },
         {
           "ssml": "End of the row."
@@ -125048,15 +124190,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -125492,19 +124632,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -125943,19 +125080,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -125964,12 +125098,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -126440,8 +125572,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -126450,12 +125581,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Engineer"
@@ -126464,12 +125593,10 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
-          "ssml": "Cell.",
-          "startsNewBlock": true
+          "ssml": "Cell."
         },
         {
           "ssml": "Admiral"
@@ -211244,8 +210371,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "End of the table."
@@ -211397,20 +210523,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         }
       ]
     },
@@ -211591,23 +210713,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
           "ssml": "End of the table."
@@ -211791,22 +210909,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -211815,8 +210930,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -212019,8 +211133,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -212029,15 +211142,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -212046,8 +211157,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -212237,26 +211347,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         }
       ]
     },
@@ -212453,8 +211559,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -212463,19 +211568,16 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
           "ssml": "End of the table."
@@ -212675,8 +211777,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -212685,8 +211786,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -212695,8 +211795,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -212705,8 +211804,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -212925,8 +212023,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -212938,8 +212035,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -212948,8 +212044,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -212958,8 +212053,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -213149,23 +212243,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -213365,26 +212455,22 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -213587,22 +212673,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -213614,8 +212697,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -213837,8 +212919,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -213847,15 +212928,13 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -213867,8 +212946,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214077,29 +213155,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -214315,8 +213389,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -214325,22 +213398,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -214559,8 +213629,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -214569,8 +213638,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -214579,8 +213647,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214592,8 +213659,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214831,8 +213897,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -214844,8 +213909,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -214854,8 +213918,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -214867,8 +213930,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -215233,12 +214295,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         }
       ]
     },
@@ -215639,16 +214699,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Ada",
-          "startsNewBlock": true
+          "ssml": "Ada"
         },
         {
-          "ssml": "Grace",
-          "startsNewBlock": true
+          "ssml": "Grace"
         },
         {
           "ssml": "End of the table."
@@ -216052,15 +215109,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -216069,8 +215124,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -216509,8 +215563,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -216519,8 +215572,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Ada"
@@ -216529,8 +215581,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Grace"
@@ -216940,15 +215991,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -217384,19 +216433,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Ada"
         },
         {
-          "ssml": "Row header.",
-          "startsNewBlock": true
+          "ssml": "Row header."
         },
         {
           "ssml": "Grace"
@@ -217835,15 +216881,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -217855,8 +216899,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -218330,8 +217373,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -218340,8 +217382,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -218353,8 +217394,7 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Row header."
@@ -218719,12 +217759,10 @@
       ],
       "utterances": [
         {
-          "ssml": "Name",
-          "startsNewBlock": true
+          "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         }
       ]
     },
@@ -219125,15 +218163,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the table."
@@ -219537,29 +218573,25 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -219995,8 +219027,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -220005,22 +219036,19 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Role",
-          "startsNewBlock": true
+          "ssml": "Role"
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -220427,15 +219455,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -220871,8 +219897,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Column header."
@@ -220881,8 +219906,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -221321,8 +220345,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "Column header."
@@ -221331,8 +220354,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -221341,15 +220363,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -221817,8 +220837,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -221830,8 +220849,7 @@
           "ssml": "Name"
         },
         {
-          "ssml": "Column header.",
-          "startsNewBlock": true
+          "ssml": "Column header."
         },
         {
           "ssml": "Role"
@@ -221840,15 +220858,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -222743,22 +221759,19 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
@@ -223714,8 +222727,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the table.",
-          "startsNewBlock": true
+          "ssml": "Start of the table."
         },
         {
           "ssml": "Start of the row."
@@ -223724,15 +222736,13 @@
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."
         },
         {
-          "ssml": "Start of the row.",
-          "startsNewBlock": true
+          "ssml": "Start of the row."
         },
         {
           "ssml": "End of the row."

--- a/fixtures/term-epub-type/utterances.json
+++ b/fixtures/term-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "lighthouse",
-          "startsNewBlock": true
+          "plain": "lighthouse"
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the glossary.",
-          "startsNewBlock": true
+          "plain": "Start of the glossary."
         },
         {
           "plain": "lighthouse"
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Term.",
-          "startsNewBlock": true
+          "plain": "Term."
         },
         {
           "plain": "lighthouse"
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the glossary.",
-          "startsNewBlock": true
+          "plain": "Start of the glossary."
         },
         {
           "plain": "Term."
@@ -251,8 +247,7 @@
       ],
       "utterances": [
         {
-          "ssml": "lighthouse",
-          "startsNewBlock": true
+          "ssml": "lighthouse"
         }
       ]
     },
@@ -319,8 +314,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the glossary.",
-          "startsNewBlock": true
+          "ssml": "Start of the glossary."
         },
         {
           "ssml": "lighthouse"
@@ -393,8 +387,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Term.",
-          "startsNewBlock": true
+          "ssml": "Term."
         },
         {
           "ssml": "lighthouse"
@@ -472,8 +465,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the glossary.",
-          "startsNewBlock": true
+          "ssml": "Start of the glossary."
         },
         {
           "ssml": "Term."

--- a/fixtures/tip-epub-type/utterances.json
+++ b/fixtures/tip-epub-type/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Tip: wind the mechanism fully before dusk.",
-          "startsNewBlock": true
+          "plain": "Tip: wind the mechanism fully before dusk."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the aside.",
-          "startsNewBlock": true
+          "plain": "Start of the aside."
         },
         {
           "plain": "Tip: wind the mechanism fully before dusk."
@@ -150,8 +148,7 @@
       ],
       "utterances": [
         {
-          "plain": "Tip.",
-          "startsNewBlock": true
+          "plain": "Tip."
         },
         {
           "plain": "Tip: wind the mechanism fully before dusk."
@@ -229,8 +226,7 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the aside.",
-          "startsNewBlock": true
+          "plain": "Start of the aside."
         },
         {
           "plain": "Tip."
@@ -568,8 +564,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Tip: wind the mechanism fully before dusk.",
-          "startsNewBlock": true
+          "ssml": "Tip: wind the mechanism fully before dusk."
         }
       ]
     },
@@ -636,8 +631,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the aside.",
-          "startsNewBlock": true
+          "ssml": "Start of the aside."
         },
         {
           "ssml": "Tip: wind the mechanism fully before dusk."
@@ -710,8 +704,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Tip.",
-          "startsNewBlock": true
+          "ssml": "Tip."
         },
         {
           "ssml": "Tip: wind the mechanism fully before dusk."
@@ -789,8 +782,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the aside.",
-          "startsNewBlock": true
+          "ssml": "Start of the aside."
         },
         {
           "ssml": "Tip."

--- a/fixtures/tip-role-aria/utterances.json
+++ b/fixtures/tip-role-aria/utterances.json
@@ -8,8 +8,7 @@
       ],
       "utterances": [
         {
-          "plain": "Tip: wind the mechanism fully before dusk.",
-          "startsNewBlock": true
+          "plain": "Tip: wind the mechanism fully before dusk."
         }
       ]
     },
@@ -76,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Tip.",
-          "startsNewBlock": true
+          "plain": "Tip."
         },
         {
           "plain": "Tip: wind the mechanism fully before dusk."
@@ -92,8 +90,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Tip: wind the mechanism fully before dusk.",
-          "startsNewBlock": true
+          "ssml": "Tip: wind the mechanism fully before dusk."
         }
       ]
     },
@@ -160,8 +157,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Tip.",
-          "startsNewBlock": true
+          "ssml": "Tip."
         },
         {
           "ssml": "Tip: wind the mechanism fully before dusk."

--- a/fixtures/toc-epub-type/utterances.json
+++ b/fixtures/toc-epub-type/utterances.json
@@ -8,16 +8,13 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         }
       ]
     },
@@ -87,16 +84,13 @@
           "plain": "Start of the table of contents."
         },
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         },
         {
           "plain": "End of the table of contents."
@@ -166,19 +160,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         },
         {
           "plain": "End of the list."
@@ -259,19 +250,16 @@
           "plain": "Start of the table of contents."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         },
         {
           "plain": "End of the list."
@@ -344,22 +332,19 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Two"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Three"
@@ -438,106 +423,6 @@
       "utterances": [
         {
           "plain": "Start of the table of contents."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Chapter One"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Chapter Two"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Chapter Three"
-        },
-        {
-          "plain": "End of the table of contents."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -546,15 +431,109 @@
           "plain": "Chapter One"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Two"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Chapter Three"
+        },
+        {
+          "plain": "End of the table of contents."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Chapter One"
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Chapter Two"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Chapter Three"
@@ -646,8 +625,7 @@
           "plain": "Start of the table of contents."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -656,15 +634,13 @@
           "plain": "Chapter One"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Two"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Three"
@@ -1362,16 +1338,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         }
       ]
     },
@@ -1441,16 +1414,13 @@
           "ssml": "Start of the table of contents."
         },
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         },
         {
           "ssml": "End of the table of contents."
@@ -1520,19 +1490,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         },
         {
           "ssml": "End of the list."
@@ -1613,19 +1580,16 @@
           "ssml": "Start of the table of contents."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         },
         {
           "ssml": "End of the list."
@@ -1698,22 +1662,19 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Two"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Three"
@@ -1792,106 +1753,6 @@
       "utterances": [
         {
           "ssml": "Start of the table of contents."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Chapter One"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Chapter Two"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Chapter Three"
-        },
-        {
-          "ssml": "End of the table of contents."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1900,15 +1761,109 @@
           "ssml": "Chapter One"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Two"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Chapter Three"
+        },
+        {
+          "ssml": "End of the table of contents."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Chapter One"
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Chapter Two"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Three"
@@ -2000,8 +1955,7 @@
           "ssml": "Start of the table of contents."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -2010,15 +1964,13 @@
           "ssml": "Chapter One"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Two"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Three"

--- a/fixtures/toc-role-aria/utterances.json
+++ b/fixtures/toc-role-aria/utterances.json
@@ -8,16 +8,13 @@
       ],
       "utterances": [
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         }
       ]
     },
@@ -87,16 +84,13 @@
           "plain": "Start of the table of contents."
         },
         {
-          "plain": "Chapter One",
-          "startsNewBlock": true
+          "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         },
         {
           "plain": "End of the table of contents."
@@ -166,19 +160,16 @@
       ],
       "utterances": [
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         },
         {
           "plain": "End of the list."
@@ -259,19 +250,16 @@
           "plain": "Start of the table of contents."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "Chapter Two",
-          "startsNewBlock": true
+          "plain": "Chapter Two"
         },
         {
-          "plain": "Chapter Three",
-          "startsNewBlock": true
+          "plain": "Chapter Three"
         },
         {
           "plain": "End of the list."
@@ -344,22 +332,19 @@
       ],
       "utterances": [
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter One"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Two"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Three"
@@ -438,106 +423,6 @@
       "utterances": [
         {
           "plain": "Start of the table of contents."
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Chapter One"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Chapter Two"
-        },
-        {
-          "plain": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "plain": "Chapter Three"
-        },
-        {
-          "plain": "End of the table of contents."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "plain",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "plain": "List item."
@@ -546,15 +431,109 @@
           "plain": "Chapter One"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Two"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
+        },
+        {
+          "plain": "Chapter Three"
+        },
+        {
+          "plain": "End of the table of contents."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "plain",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "plain": "Start of the list."
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Chapter One"
+        },
+        {
+          "plain": "List item."
+        },
+        {
+          "plain": "Chapter Two"
+        },
+        {
+          "plain": "List item."
         },
         {
           "plain": "Chapter Three"
@@ -646,8 +625,7 @@
           "plain": "Start of the table of contents."
         },
         {
-          "plain": "Start of the list.",
-          "startsNewBlock": true
+          "plain": "Start of the list."
         },
         {
           "plain": "List item."
@@ -656,15 +634,13 @@
           "plain": "Chapter One"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Two"
         },
         {
-          "plain": "List item.",
-          "startsNewBlock": true
+          "plain": "List item."
         },
         {
           "plain": "Chapter Three"
@@ -1362,16 +1338,13 @@
       ],
       "utterances": [
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         }
       ]
     },
@@ -1441,16 +1414,13 @@
           "ssml": "Start of the table of contents."
         },
         {
-          "ssml": "Chapter One",
-          "startsNewBlock": true
+          "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         },
         {
           "ssml": "End of the table of contents."
@@ -1520,19 +1490,16 @@
       ],
       "utterances": [
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         },
         {
           "ssml": "End of the list."
@@ -1613,19 +1580,16 @@
           "ssml": "Start of the table of contents."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "Chapter Two",
-          "startsNewBlock": true
+          "ssml": "Chapter Two"
         },
         {
-          "ssml": "Chapter Three",
-          "startsNewBlock": true
+          "ssml": "Chapter Three"
         },
         {
           "ssml": "End of the list."
@@ -1698,22 +1662,19 @@
       ],
       "utterances": [
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter One"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Two"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Three"
@@ -1792,106 +1753,6 @@
       "utterances": [
         {
           "ssml": "Start of the table of contents."
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Chapter One"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Chapter Two"
-        },
-        {
-          "ssml": "List item.",
-          "startsNewBlock": true
-        },
-        {
-          "ssml": "Chapter Three"
-        },
-        {
-          "ssml": "End of the table of contents."
-        }
-      ]
-    },
-    {
-      "options": [
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ]
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "always",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "block-level",
-          "inlineContextualization": true
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none"
-        },
-        {
-          "format": "ssml",
-          "contextualize": [
-            "list",
-            "listItem"
-          ],
-          "language": "none",
-          "inlineContextualization": true
-        }
-      ],
-      "utterances": [
-        {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
         },
         {
           "ssml": "List item."
@@ -1900,15 +1761,109 @@
           "ssml": "Chapter One"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Two"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Chapter Three"
+        },
+        {
+          "ssml": "End of the table of contents."
+        }
+      ]
+    },
+    {
+      "options": [
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ]
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "always",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "block-level",
+          "inlineContextualization": true
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none"
+        },
+        {
+          "format": "ssml",
+          "contextualize": [
+            "list",
+            "listItem"
+          ],
+          "language": "none",
+          "inlineContextualization": true
+        }
+      ],
+      "utterances": [
+        {
+          "ssml": "Start of the list."
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Chapter One"
+        },
+        {
+          "ssml": "List item."
+        },
+        {
+          "ssml": "Chapter Two"
+        },
+        {
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Three"
@@ -2000,8 +1955,7 @@
           "ssml": "Start of the table of contents."
         },
         {
-          "ssml": "Start of the list.",
-          "startsNewBlock": true
+          "ssml": "Start of the list."
         },
         {
           "ssml": "List item."
@@ -2010,15 +1964,13 @@
           "ssml": "Chapter One"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Two"
         },
         {
-          "ssml": "List item.",
-          "startsNewBlock": true
+          "ssml": "List item."
         },
         {
           "ssml": "Chapter Three"

--- a/fixtures/video-html-native/utterances.json
+++ b/fixtures/video-html-native/utterances.json
@@ -75,8 +75,7 @@
       ],
       "utterances": [
         {
-          "plain": "Video.",
-          "startsNewBlock": true
+          "plain": "Video."
         },
         {
           "plain": "The lamp mechanism rotating at dusk"
@@ -303,8 +302,7 @@
       ],
       "utterances": [
         {
-          "ssml": "Video.",
-          "startsNewBlock": true
+          "ssml": "Video."
         },
         {
           "ssml": "The lamp mechanism rotating at dusk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/speech",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A TypeScript library for implementing read aloud features with Web technologies, following best practices for digital publishing.",
   "author": "Readium Foundation",
   "keywords": [

--- a/src/preferences/SpeechDefaults.ts
+++ b/src/preferences/SpeechDefaults.ts
@@ -1,16 +1,16 @@
 import type { GndRole } from "../gnd/types.js";
 import {
+  autoPauseScopes,
   extractionFormats,
   languageModes,
   pauseDurationRangeConfig,
-  pauseScopes,
   pitchRangeConfig,
   rateRangeConfig,
   verbosityPresets,
   volumeRangeConfig,
 } from "./constraints.js";
 import { ensureBoolean, ensureEnumValue, ensureStringArray, ensureValueInRange } from "./guards.js";
-import type { ExtractionFormat, LanguageMode, PauseScope, VerbosityPreset } from "./SpeechPreferences.js";
+import type { AutoPauseScope, ExtractionFormat, LanguageMode, VerbosityPreset } from "./SpeechPreferences.js";
 
 // Guarded like ISpeechPreferences — an invalid value here falls back to the literal default below.
 export interface ISpeechDefaults {
@@ -21,7 +21,7 @@ export interface ISpeechDefaults {
   contextualize?: GndRole[] | null;
   language?: LanguageMode | null;
   pauseDuration?: number | null;
-  pauseScope?: PauseScope | null;
+  autoPause?: AutoPauseScope | null;
   rate?: number | null;
   pitch?: number | null;
   volume?: number | null;
@@ -35,7 +35,7 @@ export class SpeechDefaults {
   public readonly contextualize: GndRole[];
   public readonly language: LanguageMode;
   public readonly pauseDuration: number;
-  public readonly pauseScope: PauseScope;
+  public readonly autoPause: AutoPauseScope;
   public readonly rate: number;
   public readonly pitch: number;
   public readonly volume: number;
@@ -48,7 +48,7 @@ export class SpeechDefaults {
     this.contextualize = ensureStringArray(defaults.contextualize) ?? [];
     this.language = ensureEnumValue(defaults.language, languageModes) ?? "block-level";
     this.pauseDuration = ensureValueInRange(defaults.pauseDuration, pauseDurationRangeConfig.range) ?? 300;
-    this.pauseScope = ensureEnumValue(defaults.pauseScope, pauseScopes) ?? "utterance";
+    this.autoPause = ensureEnumValue(defaults.autoPause, autoPauseScopes) ?? "none";
     this.rate = ensureValueInRange(defaults.rate, rateRangeConfig.range) ?? 1.0;
     this.pitch = ensureValueInRange(defaults.pitch, pitchRangeConfig.range) ?? 1.0;
     this.volume = ensureValueInRange(defaults.volume, volumeRangeConfig.range) ?? 1.0;

--- a/src/preferences/SpeechDefaults.ts
+++ b/src/preferences/SpeechDefaults.ts
@@ -48,7 +48,7 @@ export class SpeechDefaults {
     this.verbosity = ensureEnumValue(defaults.verbosity, verbosityPresets) ?? "few";
     this.skip = ensureStringArray(defaults.skip) ?? [];
     this.contextualize = ensureStringArray(defaults.contextualize) ?? [];
-    this.language = ensureEnumValue(defaults.language, languageModes) ?? "always";
+    this.language = ensureEnumValue(defaults.language, languageModes) ?? "block-level";
     this.pauseDuration = ensureValueInRange(defaults.pauseDuration, pauseDurationRangeConfig.range) ?? 300;
     this.pauseScope = ensureEnumValue(defaults.pauseScope, pauseScopes) ?? "utterance";
     this.automaticPausesAtPageOrSpreadEnd = ensureBoolean(defaults.automaticPausesAtPageOrSpreadEnd) ?? false;

--- a/src/preferences/SpeechDefaults.ts
+++ b/src/preferences/SpeechDefaults.ts
@@ -22,7 +22,6 @@ export interface ISpeechDefaults {
   language?: LanguageMode | null;
   pauseDuration?: number | null;
   pauseScope?: PauseScope | null;
-  automaticPausesAtPageOrSpreadEnd?: boolean | null;
   rate?: number | null;
   pitch?: number | null;
   volume?: number | null;
@@ -37,7 +36,6 @@ export class SpeechDefaults {
   public readonly language: LanguageMode;
   public readonly pauseDuration: number;
   public readonly pauseScope: PauseScope;
-  public readonly automaticPausesAtPageOrSpreadEnd: boolean;
   public readonly rate: number;
   public readonly pitch: number;
   public readonly volume: number;
@@ -51,7 +49,6 @@ export class SpeechDefaults {
     this.language = ensureEnumValue(defaults.language, languageModes) ?? "block-level";
     this.pauseDuration = ensureValueInRange(defaults.pauseDuration, pauseDurationRangeConfig.range) ?? 300;
     this.pauseScope = ensureEnumValue(defaults.pauseScope, pauseScopes) ?? "utterance";
-    this.automaticPausesAtPageOrSpreadEnd = ensureBoolean(defaults.automaticPausesAtPageOrSpreadEnd) ?? false;
     this.rate = ensureValueInRange(defaults.rate, rateRangeConfig.range) ?? 1.0;
     this.pitch = ensureValueInRange(defaults.pitch, pitchRangeConfig.range) ?? 1.0;
     this.volume = ensureValueInRange(defaults.volume, volumeRangeConfig.range) ?? 1.0;

--- a/src/preferences/SpeechPreferences.ts
+++ b/src/preferences/SpeechPreferences.ts
@@ -35,7 +35,6 @@ export interface ISpeechPreferences {
   // Prosody group — consumed by ReadiumSpeechNavigator's playback sequencing.
   pauseDuration?: number | null; // ms, default 300
   pauseScope?: PauseScope | null; // "utterance" (default, pause between every utterance) | "block" (pause only at block boundaries)
-  automaticPausesAtPageOrSpreadEnd?: boolean | null; // typed, no-op today — see speechNavigator.ts
   rate?: number | null; // default 1.0, engine range [0.1, 10]
   pitch?: number | null; // default 1.0, engine range [0, 2]
   volume?: number | null; // default 1.0, engine range [0, 1]
@@ -50,7 +49,6 @@ export class SpeechPreferences implements ISpeechPreferences, ConfigurablePrefer
   public language: LanguageMode | null | undefined;
   public pauseDuration: number | null | undefined;
   public pauseScope: PauseScope | null | undefined;
-  public automaticPausesAtPageOrSpreadEnd: boolean | null | undefined;
   public rate: number | null | undefined;
   public pitch: number | null | undefined;
   public volume: number | null | undefined;
@@ -64,7 +62,6 @@ export class SpeechPreferences implements ISpeechPreferences, ConfigurablePrefer
     this.language = ensureEnumValue(preferences.language, languageModes);
     this.pauseDuration = ensureValueInRange(preferences.pauseDuration, pauseDurationRangeConfig.range);
     this.pauseScope = ensureEnumValue(preferences.pauseScope, pauseScopes);
-    this.automaticPausesAtPageOrSpreadEnd = ensureBoolean(preferences.automaticPausesAtPageOrSpreadEnd);
     this.rate = ensureValueInRange(preferences.rate, rateRangeConfig.range);
     this.pitch = ensureValueInRange(preferences.pitch, pitchRangeConfig.range);
     this.volume = ensureValueInRange(preferences.volume, volumeRangeConfig.range);

--- a/src/preferences/SpeechPreferences.ts
+++ b/src/preferences/SpeechPreferences.ts
@@ -1,10 +1,10 @@
 import type { GndRole } from "../gnd/types.js";
 import type { ConfigurablePreferences } from "./Configurable.js";
 import {
+  autoPauseScopes,
   extractionFormats,
   languageModes,
   pauseDurationRangeConfig,
-  pauseScopes,
   pitchRangeConfig,
   rateRangeConfig,
   verbosityPresets,
@@ -17,7 +17,7 @@ export type LanguageMode = "none" | "block-level" | "always";
 
 export type ExtractionFormat = "plain" | "ssml";
 
-export type PauseScope = "utterance" | "block";
+export type AutoPauseScope = "none" | "utterance" | "block";
 
 export interface ISpeechPreferences {
   // Extraction rendering — consumed by extractUtterances via the
@@ -33,8 +33,8 @@ export interface ISpeechPreferences {
   language?: LanguageMode | null;
 
   // Prosody group — consumed by ReadiumSpeechNavigator's playback sequencing.
-  pauseDuration?: number | null; // ms, default 300
-  pauseScope?: PauseScope | null; // "utterance" (default, pause between every utterance) | "block" (pause only at block boundaries)
+  pauseDuration?: number | null; // ms, default 300, delays every automatic continuation to the next utterance
+  autoPause?: AutoPauseScope | null; // "none" (default) | "utterance" | "block" — fully pauses playback instead of continuing automatically, until play() is called
   rate?: number | null; // default 1.0, engine range [0.1, 10]
   pitch?: number | null; // default 1.0, engine range [0, 2]
   volume?: number | null; // default 1.0, engine range [0, 1]
@@ -48,7 +48,7 @@ export class SpeechPreferences implements ISpeechPreferences, ConfigurablePrefer
   public contextualize: GndRole[] | null | undefined;
   public language: LanguageMode | null | undefined;
   public pauseDuration: number | null | undefined;
-  public pauseScope: PauseScope | null | undefined;
+  public autoPause: AutoPauseScope | null | undefined;
   public rate: number | null | undefined;
   public pitch: number | null | undefined;
   public volume: number | null | undefined;
@@ -61,7 +61,7 @@ export class SpeechPreferences implements ISpeechPreferences, ConfigurablePrefer
     this.contextualize = ensureStringArray(preferences.contextualize);
     this.language = ensureEnumValue(preferences.language, languageModes);
     this.pauseDuration = ensureValueInRange(preferences.pauseDuration, pauseDurationRangeConfig.range);
-    this.pauseScope = ensureEnumValue(preferences.pauseScope, pauseScopes);
+    this.autoPause = ensureEnumValue(preferences.autoPause, autoPauseScopes);
     this.rate = ensureValueInRange(preferences.rate, rateRangeConfig.range);
     this.pitch = ensureValueInRange(preferences.pitch, pitchRangeConfig.range);
     this.volume = ensureValueInRange(preferences.volume, volumeRangeConfig.range);

--- a/src/preferences/SpeechPreferencesEditor.ts
+++ b/src/preferences/SpeechPreferencesEditor.ts
@@ -39,7 +39,6 @@ export class SpeechPreferencesEditor implements IPreferencesEditor {
       language: null,
       pauseDuration: null,
       pauseScope: null,
-      automaticPausesAtPageOrSpreadEnd: null,
       rate: null,
       pitch: null,
       volume: null,
@@ -125,17 +124,6 @@ export class SpeechPreferencesEditor implements IPreferencesEditor {
       isEffective: this.preferences.pauseScope != null,
       onChange: (value) => this.updatePreference("pauseScope", value ?? null),
       supportedValues: pauseScopes,
-    });
-  }
-
-  // No page/spread boundary signal exists in this library yet, so this
-  // has no effect on playback.
-  get automaticPausesAtPageOrSpreadEnd(): BooleanPreference {
-    return new BooleanPreference({
-      initialValue: this.preferences.automaticPausesAtPageOrSpreadEnd,
-      effectiveValue: this.settings.automaticPausesAtPageOrSpreadEnd,
-      isEffective: this.preferences.automaticPausesAtPageOrSpreadEnd != null,
-      onChange: (value) => this.updatePreference("automaticPausesAtPageOrSpreadEnd", value ?? null),
     });
   }
 

--- a/src/preferences/SpeechPreferencesEditor.ts
+++ b/src/preferences/SpeechPreferencesEditor.ts
@@ -1,9 +1,9 @@
 import type { GndRole } from "../gnd/types.js";
 import {
+  autoPauseScopes,
   extractionFormats,
   languageModes,
   pauseDurationRangeConfig,
-  pauseScopes,
   pitchRangeConfig,
   rateRangeConfig,
   verbosityPresets,
@@ -11,7 +11,7 @@ import {
 } from "./constraints.js";
 import type { IPreferencesEditor } from "./PreferencesEditor.js";
 import { BooleanPreference, EnumPreference, RangePreference, StringArrayPreference } from "./Preference.js";
-import { SpeechPreferences, VerbosityPreset, LanguageMode, ExtractionFormat, PauseScope } from "./SpeechPreferences.js";
+import { SpeechPreferences, VerbosityPreset, LanguageMode, ExtractionFormat, AutoPauseScope } from "./SpeechPreferences.js";
 import { SpeechSettings } from "./SpeechSettings.js";
 
 export class SpeechPreferencesEditor implements IPreferencesEditor {
@@ -38,7 +38,7 @@ export class SpeechPreferencesEditor implements IPreferencesEditor {
       contextualize: null,
       language: null,
       pauseDuration: null,
-      pauseScope: null,
+      autoPause: null,
       rate: null,
       pitch: null,
       volume: null,
@@ -117,13 +117,13 @@ export class SpeechPreferencesEditor implements IPreferencesEditor {
     });
   }
 
-  get pauseScope(): EnumPreference<PauseScope> {
-    return new EnumPreference<PauseScope>({
-      initialValue: this.preferences.pauseScope,
-      effectiveValue: this.settings.pauseScope,
-      isEffective: this.preferences.pauseScope != null,
-      onChange: (value) => this.updatePreference("pauseScope", value ?? null),
-      supportedValues: pauseScopes,
+  get autoPause(): EnumPreference<AutoPauseScope> {
+    return new EnumPreference<AutoPauseScope>({
+      initialValue: this.preferences.autoPause,
+      effectiveValue: this.settings.autoPause,
+      isEffective: this.preferences.autoPause != null,
+      onChange: (value) => this.updatePreference("autoPause", value ?? null),
+      supportedValues: autoPauseScopes,
     });
   }
 

--- a/src/preferences/SpeechSettings.ts
+++ b/src/preferences/SpeechSettings.ts
@@ -15,7 +15,6 @@ export class SpeechSettings implements ConfigurableSettings {
   public readonly language: LanguageMode;
   public readonly pauseDuration: number;
   public readonly pauseScope: PauseScope;
-  public readonly automaticPausesAtPageOrSpreadEnd: boolean;
   public readonly rate: number;
   public readonly pitch: number;
   public readonly volume: number;
@@ -38,7 +37,6 @@ export class SpeechSettings implements ConfigurableSettings {
     this.language = preferences.language ?? defaults.language;
     this.pauseDuration = preferences.pauseDuration ?? defaults.pauseDuration;
     this.pauseScope = preferences.pauseScope ?? defaults.pauseScope;
-    this.automaticPausesAtPageOrSpreadEnd = preferences.automaticPausesAtPageOrSpreadEnd ?? defaults.automaticPausesAtPageOrSpreadEnd;
     this.rate = preferences.rate ?? defaults.rate;
     this.pitch = preferences.pitch ?? defaults.pitch;
     this.volume = preferences.volume ?? defaults.volume;

--- a/src/preferences/SpeechSettings.ts
+++ b/src/preferences/SpeechSettings.ts
@@ -1,7 +1,7 @@
 import type { GndRole } from "../gnd/types.js";
 import type { ConfigurableSettings } from "./Configurable.js";
 import { SpeechDefaults } from "./SpeechDefaults.js";
-import type { ExtractionFormat, LanguageMode, PauseScope, SpeechPreferences, VerbosityPreset } from "./SpeechPreferences.js";
+import type { AutoPauseScope, ExtractionFormat, LanguageMode, SpeechPreferences, VerbosityPreset } from "./SpeechPreferences.js";
 import { contextualizedAtVerbosity, skippableAtVerbosity } from "./verbosityTables.js";
 
 export class SpeechSettings implements ConfigurableSettings {
@@ -14,7 +14,7 @@ export class SpeechSettings implements ConfigurableSettings {
   public readonly contextualize: GndRole[];
   public readonly language: LanguageMode;
   public readonly pauseDuration: number;
-  public readonly pauseScope: PauseScope;
+  public readonly autoPause: AutoPauseScope;
   public readonly rate: number;
   public readonly pitch: number;
   public readonly volume: number;
@@ -36,7 +36,7 @@ export class SpeechSettings implements ConfigurableSettings {
     }
     this.language = preferences.language ?? defaults.language;
     this.pauseDuration = preferences.pauseDuration ?? defaults.pauseDuration;
-    this.pauseScope = preferences.pauseScope ?? defaults.pauseScope;
+    this.autoPause = preferences.autoPause ?? defaults.autoPause;
     this.rate = preferences.rate ?? defaults.rate;
     this.pitch = preferences.pitch ?? defaults.pitch;
     this.volume = preferences.volume ?? defaults.volume;

--- a/src/preferences/constraints.ts
+++ b/src/preferences/constraints.ts
@@ -1,4 +1,4 @@
-import type { ExtractionFormat, ISpeechPreferences, LanguageMode, PauseScope, VerbosityPreset } from "./SpeechPreferences.js";
+import type { AutoPauseScope, ExtractionFormat, ISpeechPreferences, LanguageMode, VerbosityPreset } from "./SpeechPreferences.js";
 
 export interface RangeConfig {
   range: [number, number];
@@ -13,7 +13,7 @@ export const volumeRangeConfig: RangeConfig = { range: [0, 1], step: 0.05 };
 export const verbosityPresets: VerbosityPreset[] = ["none", "few", "some", "most", "custom"];
 export const languageModes: LanguageMode[] = ["none", "block-level", "always"];
 export const extractionFormats: ExtractionFormat[] = ["plain", "ssml"];
-export const pauseScopes: PauseScope[] = ["utterance", "block"];
+export const autoPauseScopes: AutoPauseScope[] = ["none", "utterance", "block"];
 
 // Fields that only affect the extracted content queue, resolved via
 // ReadiumSpeechNavigator's reextract() — as opposed to the prosody group,

--- a/src/speechNavigator.ts
+++ b/src/speechNavigator.ts
@@ -38,7 +38,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
   // `loadGndContent()`. Its absence is what makes submitPreferences()'s
   // extraction-affecting fields (format, verbosity, skip, contextualize,
   // language) a no-op on content loaded via loadContent() — prosody
-  // fields (rate/pitch/volume/pauseDuration/pauseScope) still apply.
+  // fields (rate/pitch/volume/pauseDuration/autoPause) still apply.
   private source: GndObject[] | undefined;
 
   // Parallel to `contentQueue`, from the extraction that produced it — lets
@@ -46,15 +46,16 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
   private contentSources: (GndObject | undefined)[] = [];
 
   // Parallel to `contentQueue`: whether each utterance begins a new
-  // block-level element. Only extraction knows this, so content loaded via
-  // loadContent() has no boundaries of its own — pauseScope: "block" never
-  // applies a pause there, same as if none of it started a new block.
+  // block-level element. loadContent() content has no boundaries of its own.
   private contentBlockStarts: boolean[] = [];
 
   // Set by setContentQueue() when a reload should resume mid-queue rather
   // than at the start; consumed once by the engine's "ready" handler.
   private pendingResumeIndex: number | null = null;
   private pendingResumeState: "playing" | "paused" | null = null;
+
+  // Index to speak() on the next play() when autoPause has stopped playback between utterances.
+  private pendingAutoPauseIndex: number | null = null;
 
   constructor(engine: ReadiumSpeechPlaybackEngine, configuration: ReadiumSpeechNavigatorConfiguration = {}) {
     this.engine = engine;
@@ -66,7 +67,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
     void this.initializeEngine();
   }
 
-  // Unlike pauseDuration/pauseScope (read live off settings), the engine owns rate/pitch/volume and must be pushed.
+  // Unlike pauseDuration/autoPause (read live off settings), the engine owns rate/pitch/volume and must be pushed.
   private applyEngineParameters(): void {
     this.engine.setRate(this._settings.rate);
     this.engine.setPitch(this._settings.pitch);
@@ -93,18 +94,18 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
       const totalCount = this.engine.getUtteranceCount();
 
       if (currentIndex < totalCount - 1) {
-        // Navigator handles continuous playback. `pauseScope` picks which
-        // transitions get `pauseDuration`: every one ("utterance", default),
-        // or only where the next utterance starts a new block ("block").
-        // Out-of-scope transitions still yield to the event loop (delay 0),
-        // never a synchronous call.
-        const inPauseScope =
-          this._settings.pauseScope === "utterance" || this.contentBlockStarts[currentIndex + 1] === true;
-        const delay = inPauseScope ? this._settings.pauseDuration : 0;
-        this.pendingAdvanceTimeout = setTimeout(() => {
-          this.pendingAdvanceTimeout = null;
-          this.engine.speak(currentIndex + 1);
-        }, delay);
+        const inAutoPauseScope =
+          this._settings.autoPause === "utterance" || this.contentBlockStarts[currentIndex + 1] === true;
+        if (this._settings.autoPause !== "none" && inAutoPauseScope) {
+          this.pendingAutoPauseIndex = currentIndex + 1;
+          this.setNavigatorState("paused");
+          this.emitEvent({ type: "pause" });
+        } else {
+          this.pendingAdvanceTimeout = setTimeout(() => {
+            this.pendingAdvanceTimeout = null;
+            this.engine.speak(currentIndex + 1);
+          }, this._settings.pauseDuration);
+        }
       } else {
         // Reached end - set navigator to idle
         this.setNavigatorState("idle");
@@ -221,6 +222,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
   ): void {
     // Cancel any in-flight speech/pause before the reload — loadUtterances() resets the engine's index regardless.
     this.clearPendingAdvance();
+    this.pendingAutoPauseIndex = null;
     if (this.navigatorState === "playing" || this.navigatorState === "paused") {
       this.engine.stop();
     }
@@ -287,9 +289,16 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
   // Playback Control - Navigator coordinates engine operations
   play(): void {
     if (this.navigatorState === "paused") {
-      // Resume from pause
       this.setNavigatorState("playing");
-      this.engine.resume();
+      if (this.pendingAutoPauseIndex !== null) {
+        // autoPause stopped playback between utterances — nothing for the
+        // engine to resume, so speak() the utterance it was withheld on.
+        const index = this.pendingAutoPauseIndex;
+        this.pendingAutoPauseIndex = null;
+        this.engine.speak(index);
+      } else {
+        this.engine.resume();
+      }
     } else if (this.navigatorState === "ready" || this.navigatorState === "idle") {
       // Start playing from beginning
       this.setNavigatorState("playing");
@@ -303,6 +312,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
   pause(): void {
     if (this.navigatorState === "playing") {
       this.clearPendingAdvance();
+      this.pendingAutoPauseIndex = null;
       this.setNavigatorState("paused");
       this.engine.pause();
     }
@@ -310,6 +320,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
 
   stop(): void {
     this.clearPendingAdvance();
+    this.pendingAutoPauseIndex = null;
     this.setNavigatorState("idle");
     this.engine.stop();  // Reset engine index first
     this.emitEvent({ type: "stop" });  // Then emit event for UI update
@@ -338,6 +349,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
     this.clearPendingAdvance();
 
     if (this.navigatorState === "paused" && !forcePlay) {
+      if (this.pendingAutoPauseIndex !== null) this.pendingAutoPauseIndex = targetIndex;
       // For paused state, just update the index without speaking
       this.engine.setCurrentUtteranceIndex(targetIndex, (success) => {
         if (success) {
@@ -348,6 +360,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
         }
       });
     } else {
+      this.pendingAutoPauseIndex = null;
       this.setNavigatorState("playing");
       this.engine.speak(targetIndex);
     }

--- a/src/speechNavigator.ts
+++ b/src/speechNavigator.ts
@@ -45,6 +45,12 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
   // reextract() find where to resume after a reload (see resolveResumeIndex).
   private contentSources: (GndObject | undefined)[] = [];
 
+  // Parallel to `contentQueue`: whether each utterance begins a new
+  // block-level element. Only extraction knows this, so content loaded via
+  // loadContent() has no boundaries of its own — pauseScope: "block" never
+  // applies a pause there, same as if none of it started a new block.
+  private contentBlockStarts: boolean[] = [];
+
   // Set by setContentQueue() when a reload should resume mid-queue rather
   // than at the start; consumed once by the engine's "ready" handler.
   private pendingResumeIndex: number | null = null;
@@ -93,7 +99,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
         // Out-of-scope transitions still yield to the event loop (delay 0),
         // never a synchronous call.
         const inPauseScope =
-          this._settings.pauseScope === "utterance" || this.contentQueue[currentIndex + 1]?.startsNewBlock === true;
+          this._settings.pauseScope === "utterance" || this.contentBlockStarts[currentIndex + 1] === true;
         const delay = inPauseScope ? this._settings.pauseDuration : 0;
         this.pendingAdvanceTimeout = setTimeout(() => {
           this.pendingAdvanceTimeout = null;
@@ -240,7 +246,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
     const oldSources = this.contentSources;
     const oldIndex = this.getCurrentUtteranceIndex();
 
-    const { utterances, sources } = extractUtterancesWithSources(this.source, {
+    const { utterances, sources, blockStarts } = extractUtterancesWithSources(this.source, {
       format: this._settings.format,
       inlineContextualization: this._settings.inlineContextualization,
       skip: this._settings.skip,
@@ -248,6 +254,7 @@ export class ReadiumSpeechNavigator implements ReadiumSpeechNavigatorContract {
       language: this._settings.language,
     });
     this.contentSources = sources;
+    this.contentBlockStarts = blockStarts;
 
     const resumeIndex = resumeState ? this.resolveResumeIndex(oldSources, oldIndex, sources) : null;
     this.setContentQueue(utterances, resumeIndex, resumeState);

--- a/src/utterance.ts
+++ b/src/utterance.ts
@@ -1,7 +1,6 @@
 export interface ReadiumSpeechUtterance {
-  id?: string;           // Unique identifier for this content
-  plain?: string;        // Plain-text rendering, when available
-  ssml?: string;         // SSML rendering, when available
-  language?: string;     // Language of this content (BCP 47)
-  startsNewBlock?: true; // Present (and true) only when this utterance begins a new block-level element
+  id?: string;       // Unique identifier for this content
+  plain?: string;    // Plain-text rendering, when available
+  ssml?: string;     // SSML rendering, when available
+  language?: string; // Language of this content (BCP 47)
 }

--- a/src/utterances/extractUtterances.ts
+++ b/src/utterances/extractUtterances.ts
@@ -23,6 +23,10 @@ interface WalkContext {
   format: "plain" | "ssml";
   inlineContextualization: boolean;
   language?: "none" | "block-level" | "always";
+  // Tracked by object identity rather than threaded as a parallel array,
+  // since utterances get merged/reordered across several local `out` arrays
+  // (pieces, inner, ...) before reaching the caller's own `out`.
+  blockStarts: Set<ReadiumSpeechUtterance>;
 }
 
 // Parallel to `out`: which node produced each utterance, `undefined` when none (e.g. a merged span).
@@ -316,7 +320,7 @@ function walkNode(node: GndObject, out: ReadiumSpeechUtterance[], sources: Sourc
   }
 
   if (eligible && out.length > beforeLength) {
-    out[beforeLength].startsNewBlock = true;
+    ctx.blockStarts.add(out[beforeLength]);
   }
 
   // A description is supplementary/elaborating content (e.g. an extended
@@ -347,6 +351,7 @@ function makeWalkContext(options: ExtractUtterancesOptions): WalkContext {
     format: options.format ?? "plain",
     inlineContextualization: options.inlineContextualization ?? false,
     language: options.language,
+    blockStarts: new Set(),
   };
 }
 
@@ -368,14 +373,17 @@ export function extractUtterances(
 }
 
 /**
- * Same as `extractUtterances()`, plus `sources[i]`: the node that produced `utterances[i]`.
+ * Same as `extractUtterances()`, plus `sources[i]`: the node that produced `utterances[i]`,
+ * and `blockStarts[i]`: whether `utterances[i]` begins a new block-level element.
  */
 export function extractUtterancesWithSources(
   nodes: GndObject[],
   options: ExtractUtterancesOptions,
-): { utterances: ReadiumSpeechUtterance[]; sources: (GndObject | undefined)[] } {
+): { utterances: ReadiumSpeechUtterance[]; sources: (GndObject | undefined)[]; blockStarts: boolean[] } {
   const utterances: ReadiumSpeechUtterance[] = [];
   const sources: SourceTrace = [];
-  walk(nodes, utterances, sources, makeWalkContext(options), false);
-  return { utterances, sources };
+  const ctx = makeWalkContext(options);
+  walk(nodes, utterances, sources, ctx, false);
+  const blockStarts = utterances.map((utterance) => ctx.blockStarts.has(utterance));
+  return { utterances, sources, blockStarts };
 }

--- a/src/utterances/extractUtterances.ts
+++ b/src/utterances/extractUtterances.ts
@@ -51,6 +51,28 @@ function push(out: ReadiumSpeechUtterance[], sources: SourceTrace, node: GndObje
   for (let i = 0; i < items.length; i++) sources.push(node);
 }
 
+// Pushes `pieces` (or their `merged` replacement, if provided) to `out`.
+// `mergeUtterances()` returns a new object rather than one of `pieces` —
+// this carries a block-start marker over from any input piece that had
+// one, so merging never silently drops it.
+function pushPiecesOrMerged(
+  out: ReadiumSpeechUtterance[],
+  sources: SourceTrace,
+  ctx: WalkContext,
+  node: GndObject,
+  pieces: ReadiumSpeechUtterance[],
+  pieceSources: SourceTrace,
+  merged: ReadiumSpeechUtterance | undefined,
+): void {
+  if (merged) {
+    if (pieces.some((piece) => ctx.blockStarts.has(piece))) ctx.blockStarts.add(merged);
+    push(out, sources, pieceSources[0] ?? node, [merged]);
+  } else {
+    out.push(...pieces);
+    sources.push(...pieceSources);
+  }
+}
+
 // Looks up `role`'s entry in the catalog and speaks the appropriate half
 // of it for this `phase`: a plain entry only has anything to say at
 // "before" (a single, self-contained announcement); a `{start, end}` pair
@@ -221,12 +243,7 @@ function emitInterrupted(
     pieceSources.push(node);
   }
   const merged = pieces.length > 1 ? mergeUtterances(pieces, ctx.format) : undefined;
-  if (merged) {
-    push(out, sources, pieceSources[0] ?? node, [merged]);
-  } else {
-    out.push(...pieces);
-    sources.push(...pieceSources);
-  }
+  pushPiecesOrMerged(out, sources, ctx, node, pieces, pieceSources, merged);
 }
 
 function walkNode(node: GndObject, out: ReadiumSpeechUtterance[], sources: SourceTrace, ctx: WalkContext, suppress: boolean): void {
@@ -287,12 +304,7 @@ function walkNode(node: GndObject, out: ReadiumSpeechUtterance[], sources: Sourc
           pieceSources.push(child);
         }
         const merged = entry !== undefined && pieces.length > 1 ? mergeUtterances(pieces, ctx.format) : undefined;
-        if (merged) {
-          push(out, sources, pieceSources[0] ?? child, [merged]);
-        } else {
-          out.push(...pieces);
-          sources.push(...pieceSources);
-        }
+        pushPiecesOrMerged(out, sources, ctx, child, pieces, pieceSources, merged);
       } else {
         walk([child], out, sources, ctx, suppress);
       }

--- a/test/navigator/speechNavigator.test.ts
+++ b/test/navigator/speechNavigator.test.ts
@@ -146,7 +146,7 @@ test("initial preferences are configurable via the constructor", (t) => {
   t.is(navigator.settings.rate, 2);
 });
 
-test("pauseDuration delays the next speak() call under the default pauseScope (utterance)", async (t) => {
+test("pauseDuration delays the next speak() call", async (t) => {
   const engine = new MockEngine();
   const navigator = new ReadiumSpeechNavigator(engine);
   navigator.loadContent([
@@ -180,35 +180,77 @@ test("a zero pauseDuration still yields to the event loop, but resolves on the n
   t.is(engine.speakCalls.length, 1);
 });
 
-test("pauseScope 'block' skips pauseDuration when the next utterance doesn't start a new block", async (t) => {
+test("autoPause 'utterance' fully pauses instead of continuing automatically", async (t) => {
+  const engine = new MockEngine();
+  const navigator = new ReadiumSpeechNavigator(engine);
+  navigator.loadContent([
+    { plain: "First.", language: "en" },
+    { plain: "Second.", language: "en" },
+  ]);
+  navigator.submitPreferences(new SpeechPreferences({ autoPause: "utterance" }));
+
+  engine.emit({ type: "end" });
+  t.is(navigator.getState(), "paused");
+  t.is(engine.speakCalls.length, 0, "no automatic continuation while auto-paused");
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  t.is(engine.speakCalls.length, 0, "still paused after a delay — this isn't pauseDuration");
+
+  navigator.play();
+  t.is(navigator.getState(), "playing");
+  t.is(engine.speakCalls.length, 1);
+  t.is(engine.getCurrentUtteranceIndex(), 1);
+});
+
+test("autoPause 'block' does not pause when the next utterance doesn't start a new block", async (t) => {
   const engine = new MockEngine();
   const navigator = new ReadiumSpeechNavigator(engine);
   navigator.loadContent([
     { plain: "First.", language: "en" },
     { plain: "Still the same block.", language: "en" },
   ]);
-  navigator.submitPreferences(new SpeechPreferences({ pauseDuration: 60, pauseScope: "block" }));
+  navigator.submitPreferences(new SpeechPreferences({ autoPause: "block", pauseDuration: 0 }));
 
   engine.emit({ type: "end" });
-  t.is(engine.speakCalls.length, 0, "still async — setTimeout with delay 0, not a synchronous call");
+  t.is(engine.speakCalls.length, 0, "still async — setTimeout, not a synchronous call");
+  t.not(navigator.getState(), "paused", "no block boundary here, so autoPause never triggers");
 
   await new Promise((resolve) => setTimeout(resolve, 0));
-  t.is(engine.speakCalls.length, 1);
+  t.is(engine.speakCalls.length, 1, "continues automatically, delayed only by pauseDuration");
 });
 
-test("pauseScope 'block' applies pauseDuration when the next utterance starts a new block", async (t) => {
+test("autoPause 'block' pauses when the next utterance starts a new block", async (t) => {
   const engine = new MockEngine();
   const navigator = new ReadiumSpeechNavigator(engine);
   navigator.loadGndContent(twoParagraphTree);
-  navigator.submitPreferences(new SpeechPreferences({ pauseDuration: 60, pauseScope: "block" }));
+  navigator.submitPreferences(new SpeechPreferences({ autoPause: "block" }));
 
-  const before = Date.now();
   engine.emit({ type: "end" });
-  t.is(engine.speakCalls.length, 0, "speak() must not fire synchronously when a pause is configured");
+  t.is(navigator.getState(), "paused");
+  t.is(engine.speakCalls.length, 0);
 
-  await new Promise((resolve) => setTimeout(resolve, 120));
+  navigator.play();
   t.is(engine.speakCalls.length, 1);
-  t.true(engine.speakCalls[0] - before >= 50);
+  t.is(engine.getCurrentUtteranceIndex(), 1);
+});
+
+test("jumping while auto-paused resumes at the jumped-to index, not the original one", async (t) => {
+  const engine = new MockEngine();
+  const navigator = new ReadiumSpeechNavigator(engine);
+  navigator.loadContent([
+    { plain: "First.", language: "en" },
+    { plain: "Second.", language: "en" },
+    { plain: "Third.", language: "en" },
+  ]);
+  navigator.submitPreferences(new SpeechPreferences({ autoPause: "utterance" }));
+
+  engine.emit({ type: "end" }); // finishes index 0, auto-pauses before index 1
+  t.is(navigator.getState(), "paused");
+
+  navigator.jumpTo(2, false);
+  navigator.play();
+  t.is(engine.speakCalls.length, 1);
+  t.is(engine.getCurrentUtteranceIndex(), 2);
 });
 
 test("prosody-only submitPreferences mid-playback does not reload the queue", async (t) => {

--- a/test/navigator/speechNavigator.test.ts
+++ b/test/navigator/speechNavigator.test.ts
@@ -21,7 +21,7 @@ test("loadGndContent extracts with the default (few) verbosity", (t) => {
   const engine = new MockEngine();
   const navigator = new ReadiumSpeechNavigator(engine);
   navigator.loadGndContent(chapterTree);
-  t.deepEqual(navigator.getContentQueue(), [{ language: "en", plain: "Hello world.", startsNewBlock: true }]);
+  t.deepEqual(navigator.getContentQueue(), [{ language: "en", plain: "Hello world." }]);
 });
 
 test("submitPreferences re-extracts content loaded via loadGndContent", (t) => {
@@ -30,7 +30,7 @@ test("submitPreferences re-extracts content loaded via loadGndContent", (t) => {
   navigator.loadGndContent(chapterTree);
   navigator.submitPreferences(new SpeechPreferences({ verbosity: "most" }));
   t.deepEqual(navigator.getContentQueue(), [
-    { plain: "Start of the chapter.", startsNewBlock: true },
+    { plain: "Start of the chapter." },
     { language: "en", plain: "Hello world." },
     { plain: "End of the chapter." },
   ]);
@@ -199,10 +199,7 @@ test("pauseScope 'block' skips pauseDuration when the next utterance doesn't sta
 test("pauseScope 'block' applies pauseDuration when the next utterance starts a new block", async (t) => {
   const engine = new MockEngine();
   const navigator = new ReadiumSpeechNavigator(engine);
-  navigator.loadContent([
-    { plain: "First.", language: "en" },
-    { plain: "New paragraph.", language: "en", startsNewBlock: true },
-  ]);
+  navigator.loadGndContent(twoParagraphTree);
   navigator.submitPreferences(new SpeechPreferences({ pauseDuration: 60, pauseScope: "block" }));
 
   const before = Date.now();

--- a/test/preferences/speechDefaults.test.ts
+++ b/test/preferences/speechDefaults.test.ts
@@ -5,7 +5,7 @@ test("defaults to the built-in literals when constructed with nothing", (t) => {
   const defaults = new SpeechDefaults();
   t.is(defaults.format, "plain");
   t.is(defaults.verbosity, "few");
-  t.is(defaults.language, "always");
+  t.is(defaults.language, "block-level");
   t.is(defaults.pauseDuration, 300);
   t.is(defaults.pauseScope, "utterance");
   t.is(defaults.rate, 1);

--- a/test/preferences/speechDefaults.test.ts
+++ b/test/preferences/speechDefaults.test.ts
@@ -7,7 +7,7 @@ test("defaults to the built-in literals when constructed with nothing", (t) => {
   t.is(defaults.verbosity, "few");
   t.is(defaults.language, "block-level");
   t.is(defaults.pauseDuration, 300);
-  t.is(defaults.pauseScope, "utterance");
+  t.is(defaults.autoPause, "none");
   t.is(defaults.rate, 1);
   t.is(defaults.pitch, 1);
   t.is(defaults.volume, 1);

--- a/test/preferences/speechPreferences.test.ts
+++ b/test/preferences/speechPreferences.test.ts
@@ -65,14 +65,14 @@ test("an unsupported enum value is dropped to undefined", (t) => {
     // @ts-expect-error deliberately invalid
     verbosity: "everything",
     // @ts-expect-error deliberately invalid
-    pauseScope: "sentence",
+    autoPause: "sentence",
     // @ts-expect-error deliberately invalid
     format: "audio",
     // @ts-expect-error deliberately invalid
     language: "sometimes",
   });
   t.is(prefs.verbosity, undefined);
-  t.is(prefs.pauseScope, undefined);
+  t.is(prefs.autoPause, undefined);
   t.is(prefs.format, undefined);
   t.is(prefs.language, undefined);
 });

--- a/test/preferences/speechPreferences.test.ts
+++ b/test/preferences/speechPreferences.test.ts
@@ -81,11 +81,8 @@ test("a non-boolean value for a boolean field is dropped to undefined", (t) => {
   const prefs = new SpeechPreferences({
     // @ts-expect-error deliberately invalid
     inlineContextualization: "yes",
-    // @ts-expect-error deliberately invalid
-    automaticPausesAtPageOrSpreadEnd: 1,
   });
   t.is(prefs.inlineContextualization, undefined);
-  t.is(prefs.automaticPausesAtPageOrSpreadEnd, undefined);
 });
 
 test("explicit null is preserved (not coerced to undefined) for guarded fields", (t) => {

--- a/test/preferences/speechPreferencesEditor.test.ts
+++ b/test/preferences/speechPreferencesEditor.test.ts
@@ -78,13 +78,6 @@ test("clear() actually resets preferences submitted through submitPreferences()"
   t.is(merged.pauseDuration, null);
 });
 
-test("automaticPausesAtPageOrSpreadEnd is a plain, settable preference", (t) => {
-  const editor = makeEditor();
-  t.false(editor.automaticPausesAtPageOrSpreadEnd.isEffective);
-  editor.automaticPausesAtPageOrSpreadEnd.value = true;
-  t.is(editor.preferences.automaticPausesAtPageOrSpreadEnd, true);
-});
-
 test("rate is a range preference with the expected bounds", (t) => {
   const editor = makeEditor();
   t.deepEqual(editor.rate.supportedRange, [0.1, 10]);

--- a/test/preferences/speechPreferencesEditor.test.ts
+++ b/test/preferences/speechPreferencesEditor.test.ts
@@ -45,19 +45,19 @@ test("pauseDuration is a range preference with the expected bounds", (t) => {
   t.is(editor.pauseDuration.effectiveValue, 300);
 });
 
-test("pauseScope: unset preference reports the effective default and isEffective false", (t) => {
+test("autoPause: unset preference reports the effective default and isEffective false", (t) => {
   const editor = makeEditor();
-  t.is(editor.pauseScope.value, null);
-  t.is(editor.pauseScope.effectiveValue, "utterance");
-  t.false(editor.pauseScope.isEffective);
-  t.deepEqual(editor.pauseScope.supportedValues, ["utterance", "block"]);
+  t.is(editor.autoPause.value, null);
+  t.is(editor.autoPause.effectiveValue, "none");
+  t.false(editor.autoPause.isEffective);
+  t.deepEqual(editor.autoPause.supportedValues, ["none", "utterance", "block"]);
 });
 
-test("pauseScope: an explicit preference is effective and matches the resolved settings", (t) => {
-  const editor = makeEditor(new SpeechPreferences({ pauseScope: "block" }));
-  t.is(editor.pauseScope.value, "block");
-  t.is(editor.pauseScope.effectiveValue, "block");
-  t.true(editor.pauseScope.isEffective);
+test("autoPause: an explicit preference is effective and matches the resolved settings", (t) => {
+  const editor = makeEditor(new SpeechPreferences({ autoPause: "block" }));
+  t.is(editor.autoPause.value, "block");
+  t.is(editor.autoPause.effectiveValue, "block");
+  t.true(editor.autoPause.isEffective);
 });
 
 test("clear() resets preferences to explicit nulls, not undefined", (t) => {

--- a/test/preferences/speechSettings.test.ts
+++ b/test/preferences/speechSettings.test.ts
@@ -13,7 +13,7 @@ test("defaults to the few preset and the rest of SpeechDefaults", (t) => {
   t.is(settings.inlineContextualization, false);
   t.is(settings.language, "block-level");
   t.is(settings.pauseDuration, 300);
-  t.is(settings.pauseScope, "utterance");
+  t.is(settings.autoPause, "none");
   t.is(settings.rate, 1);
   t.is(settings.pitch, 1);
   t.is(settings.volume, 1);

--- a/test/preferences/speechSettings.test.ts
+++ b/test/preferences/speechSettings.test.ts
@@ -11,7 +11,7 @@ test("defaults to the few preset and the rest of SpeechDefaults", (t) => {
   t.is(settings.verbosity, "few");
   t.is(settings.format, "plain");
   t.is(settings.inlineContextualization, false);
-  t.is(settings.language, "always");
+  t.is(settings.language, "block-level");
   t.is(settings.pauseDuration, 300);
   t.is(settings.pauseScope, "utterance");
   t.is(settings.automaticPausesAtPageOrSpreadEnd, false);

--- a/test/preferences/speechSettings.test.ts
+++ b/test/preferences/speechSettings.test.ts
@@ -14,7 +14,6 @@ test("defaults to the few preset and the rest of SpeechDefaults", (t) => {
   t.is(settings.language, "block-level");
   t.is(settings.pauseDuration, 300);
   t.is(settings.pauseScope, "utterance");
-  t.is(settings.automaticPausesAtPageOrSpreadEnd, false);
   t.is(settings.rate, 1);
   t.is(settings.pitch, 1);
   t.is(settings.volume, 1);


### PR DESCRIPTION
This PR makes a couple of adjustments to Preferences and extracting utterances: 

- `block-level` is now the default for language preference
- start of new block for `pauseScope` is now handled internally, and does not leak into fixtures and Utterances Interface
- corrects autoPause preference