### PR TITLE
Filter online voices on recoverable failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows [Semantic Versioning](https://semver.org/).
 
+## [0.8.1] - 2026-09-01
+
+### Fixed
+
+- `FallbackSpeechEngine` no longer picks a fallback voice that requires network access unless `navigator.onLine` is confirmed `true`, defaulting to offline-only when connectivity is unknown — previously it could pick an online voice while swapping away from a recoverable failure, risking the same failure again.
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readium/speech",
-  "version": "0.2.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@readium/speech",
-      "version": "0.2.0",
+      "version": "0.8.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@readium/decorator": "^1.0.1",
@@ -698,16 +698,16 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/diff": {
@@ -1913,9 +1913,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2758,9 +2758,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {
@@ -3618,9 +3618,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3965,9 +3965,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4286,9 +4286,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4306,7 +4306,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4555,16 +4555,16 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
@@ -5171,9 +5171,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/speech",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A TypeScript library for implementing read aloud features with Web technologies, following best practices for digital publishing.",
   "author": "Readium Foundation",
   "keywords": [

--- a/src/Fallback/fallbackSpeechEngine.ts
+++ b/src/Fallback/fallbackSpeechEngine.ts
@@ -302,7 +302,8 @@ export class FallbackSpeechEngine implements ReadiumSpeechPlaybackEngine {
         const failedVoice = primaryEngine.getCurrentVoice() ?? (typeof this.lastVoiceRequest === "object" ? this.lastVoiceRequest : null);
         const language = failedVoice?.language || this.currentUtterances[this.desiredIndex]?.language || (typeof navigator !== "undefined" ? navigator.language : "en");
         bestVoice = await this.pickBestFallbackVoice(language, failedVoice?.gender);
-        return this.fallbackProvider.createEngine(bestVoice ?? undefined);
+        if (!bestVoice) throw new Error("no offline-available fallback voice found");
+        return this.fallbackProvider.createEngine(bestVoice);
       },
       () => {
         this.hasFallenBack = true;
@@ -382,12 +383,19 @@ export class FallbackSpeechEngine implements ReadiumSpeechPlaybackEngine {
     await oldEngine.destroy();
   }
 
+  // Only skip the offlineAvailability filter when navigator.onLine is confirmed true — unknown
+  // (unimplemented navigator.onLine) defaults to restricting, not to allowing online voices.
+  //
   // Language narrows first, gender second: a same-language wrong-gender voice beats a
   // different-language right-gender one. Falls back to any language if none matches, then to
   // any gender within that if none matches. Region/quality ranking within the final candidate
   // set is delegated to pickBestVoiceByRegion, the same ranking logic sortVoicesByRegions uses.
   private async pickBestFallbackVoice(language: string, gender: ReadiumSpeechVoice["gender"]): Promise<ReadiumSpeechVoice | null> {
-    const voices = await this.fallbackProvider.getVoices();
+    const allVoices = await this.fallbackProvider.getVoices();
+    const isOnlineConfirmed = typeof navigator !== "undefined" && navigator.onLine === true;
+    const voices = isOnlineConfirmed ? allVoices : allVoices.filter(voice => voice.offlineAvailability === true);
+    if (voices.length === 0) return null;
+
     const [processedLang] = processLanguages([language]);
     const { voicesByLang } = groupVoicesByLanguage(voices, [processedLang]);
     const byLanguage = voicesByLang.get(processedLang.baseLang) ?? [];

--- a/test/Fallback/fallbackSpeechEngine.test.ts
+++ b/test/Fallback/fallbackSpeechEngine.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 import { FallbackSpeechEngine } from "../../build/index.js";
-import { FakeEngine, FakeFallbackProvider, FakePrimaryProvider, tick, wait, deferred } from "./testUtils.js";
+import { FakeEngine, FakeFallbackProvider, FakePrimaryProvider, tick, wait, deferred, stubOnLine } from "./testUtils.js";
 
 // =============================================
 // Basic delegation
@@ -80,6 +80,117 @@ test.serial("falls back to a language-only match when no voice satisfies both la
 
   t.truthy(fallbackProvider.receivedVoice, "a voice was still picked");
   t.is(fallbackProvider.receivedVoice.language, "fr-FR", "language-only match, gender requirement dropped");
+});
+
+test.serial("while offline, only considers offline-available voices, since an online one would risk the same network failure", async (t) => {
+  const restoreOnLine = stubOnLine(false);
+  t.teardown(restoreOnLine);
+
+  const primary = new FakeEngine();
+  primary.setCurrentVoiceForTest({ language: "fr-FR", gender: "female" });
+
+  const fallbackProvider = new FakeFallbackProvider();
+  fallbackProvider.voices = fallbackProvider.voices.map(voice =>
+    voice.name === "French Female" ? { ...voice, offlineAvailability: false } : voice
+  );
+  const wrapper = new FallbackSpeechEngine({ primaryEngine: primary as any, primaryProvider: new FakePrimaryProvider() as any, fallbackProvider: fallbackProvider as any });
+  wrapper.loadUtterances([{ plain: "hello" }]);
+
+  primary.emit("error", { message: "network failure", recoverable: true });
+  await tick();
+
+  t.is(fallbackProvider.receivedVoice?.name, "French Male", "skipped the best language+gender match because it needs network, picked the offline-available one instead");
+});
+
+test.serial("when navigator.onLine is unimplemented, defaults to restricting to offline-available voices", async (t) => {
+  const restoreOnLine = stubOnLine(undefined as unknown as boolean);
+  t.teardown(restoreOnLine);
+
+  const primary = new FakeEngine();
+  primary.setCurrentVoiceForTest({ language: "fr-FR", gender: "female" });
+
+  const fallbackProvider = new FakeFallbackProvider();
+  fallbackProvider.voices = fallbackProvider.voices.map(voice =>
+    voice.name === "French Female" ? { ...voice, offlineAvailability: false } : voice
+  );
+  const wrapper = new FallbackSpeechEngine({ primaryEngine: primary as any, primaryProvider: new FakePrimaryProvider() as any, fallbackProvider: fallbackProvider as any });
+  wrapper.loadUtterances([{ plain: "hello" }]);
+
+  primary.emit("error", { message: "network failure", recoverable: true });
+  await tick();
+
+  t.is(fallbackProvider.receivedVoice?.name, "French Male", "unknown connectivity is not treated as confirmed online");
+});
+
+test.serial("while offline, forwards the original error instead of swapping when nothing offline-available is left", async (t) => {
+  const restoreOnLine = stubOnLine(false);
+  t.teardown(restoreOnLine);
+
+  const primary = new FakeEngine();
+  primary.setCurrentVoiceForTest({ language: "fr-FR", gender: "female" });
+
+  const fallbackProvider = new FakeFallbackProvider();
+  fallbackProvider.voices = fallbackProvider.voices.map(voice => ({ ...voice, offlineAvailability: false }));
+  const wrapper = new FallbackSpeechEngine({ primaryEngine: primary as any, primaryProvider: new FakePrimaryProvider() as any, fallbackProvider: fallbackProvider as any });
+  wrapper.loadUtterances([{ plain: "hello" }]);
+
+  const errors: any[] = [];
+  wrapper.on("error", (e: any) => errors.push(e));
+  const fallbackEvents: any[] = [];
+  wrapper.on("enginefallback", (e: any) => fallbackEvents.push(e));
+
+  primary.emit("error", { message: "network failure", recoverable: true });
+  await tick();
+
+  t.is(fallbackProvider.receivedVoice, undefined, "no engine created, since it would only fail again the same way");
+  t.is(fallbackEvents.length, 0);
+  t.is(errors.length, 1);
+  t.is(errors[0].detail.message, "network failure", "the original failure, not a generic wrapper error");
+});
+
+test.serial("while offline, forwards the original error when the fallback provider never reports offline availability at all (e.g. an always-online provider)", async (t) => {
+  const restoreOnLine = stubOnLine(false);
+  t.teardown(restoreOnLine);
+
+  const primary = new FakeEngine();
+  primary.setCurrentVoiceForTest({ language: "fr-FR", gender: "female" });
+
+  const fallbackProvider = new FakeFallbackProvider();
+  // Simulates a provider like SpeechServerEngineProvider, which never sets offlineAvailability
+  // on any voice (always undefined), rather than WebSpeech's true/false.
+  fallbackProvider.voices = fallbackProvider.voices.map(({ offlineAvailability, ...voice }) => voice);
+  const wrapper = new FallbackSpeechEngine({ primaryEngine: primary as any, primaryProvider: new FakePrimaryProvider() as any, fallbackProvider: fallbackProvider as any });
+  wrapper.loadUtterances([{ plain: "hello" }]);
+
+  const errors: any[] = [];
+  wrapper.on("error", (e: any) => errors.push(e));
+
+  primary.emit("error", { message: "network failure", recoverable: true });
+  await tick();
+
+  t.is(fallbackProvider.receivedVoice, undefined, "no engine created for an always-online-style provider");
+  t.is(errors.length, 1);
+  t.is(errors[0].detail.message, "network failure");
+});
+
+test.serial("while online, does not restrict to offline-available voices", async (t) => {
+  const restoreOnLine = stubOnLine(true);
+  t.teardown(restoreOnLine);
+
+  const primary = new FakeEngine();
+  primary.setCurrentVoiceForTest({ language: "fr-FR", gender: "female" });
+
+  const fallbackProvider = new FakeFallbackProvider();
+  fallbackProvider.voices = fallbackProvider.voices.map(voice =>
+    voice.name === "French Female" ? { ...voice, offlineAvailability: false } : voice
+  );
+  const wrapper = new FallbackSpeechEngine({ primaryEngine: primary as any, primaryProvider: new FakePrimaryProvider() as any, fallbackProvider: fallbackProvider as any });
+  wrapper.loadUtterances([{ plain: "hello" }]);
+
+  primary.emit("error", { message: "network failure", recoverable: true });
+  await tick();
+
+  t.is(fallbackProvider.receivedVoice?.name, "French Female", "picked the best language+gender match even though it needs network, since the device is online");
 });
 
 test.serial("does not swap on a non-recoverable error, forwards it as-is", async (t) => {

--- a/test/Fallback/testUtils.ts
+++ b/test/Fallback/testUtils.ts
@@ -273,7 +273,10 @@ export function deferred(): { promise: Promise<void>; resolve: () => void } {
 
 // Stubs navigator.onLine for the duration of one test; returns a restore function.
 export function stubOnLine(value: boolean): () => void {
-  const original = navigator.onLine;
+  const original = Object.getOwnPropertyDescriptor(navigator, "onLine");
   Object.defineProperty(navigator, "onLine", { value, configurable: true });
-  return () => Object.defineProperty(navigator, "onLine", { value: original, configurable: true });
+  return () => {
+    if (original) Object.defineProperty(navigator, "onLine", original);
+    else delete (navigator as { onLine?: boolean }).onLine;
+  };
 }

--- a/test/Fallback/testUtils.ts
+++ b/test/Fallback/testUtils.ts
@@ -187,9 +187,9 @@ export class FakeFallbackProvider {
   // Seeded by default so pickBestFallbackVoice()'s language/gender matching has something
   // deterministic to pick from; override per-test to exercise other matches.
   voices: ReadiumSpeechVoice[] = [
-    makeReadiumVoice({ name: "French Female", language: "fr-FR", gender: "female" }),
-    makeReadiumVoice({ name: "French Male", language: "fr-FR", gender: "male" }),
-    makeReadiumVoice({ name: "English Female", language: "en-US", gender: "female" })
+    makeReadiumVoice({ name: "French Female", language: "fr-FR", gender: "female", offlineAvailability: true }),
+    makeReadiumVoice({ name: "French Male", language: "fr-FR", gender: "male", offlineAvailability: true }),
+    makeReadiumVoice({ name: "English Female", language: "en-US", gender: "female", offlineAvailability: true })
   ];
 
   async getVoices(): Promise<ReadiumSpeechVoice[]> {
@@ -269,4 +269,11 @@ export function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void;
   const promise = new Promise<void>(r => { resolve = r; });
   return { promise, resolve };
+}
+
+// Stubs navigator.onLine for the duration of one test; returns a restore function.
+export function stubOnLine(value: boolean): () => void {
+  const original = navigator.onLine;
+  Object.defineProperty(navigator, "onLine", { value, configurable: true });
+  return () => Object.defineProperty(navigator, "onLine", { value: original, configurable: true });
 }


### PR DESCRIPTION
This PR implements a patch so that, in case the network is offline, we do not attempt to pick up from online voices for the fallback engine. 

This is super restrictive in the sense it really needs to pass two restrictive checks:

- `navigator.onLine === true`
- `voice.offlineAvailability === true`

So in case onLine is not implemented, it is considered offline, and if a voice does not have offlineAvailability set (`undefined`) it is considered online hence non-reachable offline. 